### PR TITLE
chore(build): baseline C# langversion + editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+root = true
+
+[*.{cs,vb}]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.cs]
+# Namespaces en file-scoped (C#10)
+csharp_style_namespace_declarations = file_scoped:suggestion
+
+# Using en haut, triés
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = true
+
+# var et patterns modernes : laissez “suggestion” (on durcira plus tard)
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+
+# Nommage: _camelCase pour champs privés
+dotnet_naming_rule.private_fields_should_be_camel_with_underscore.severity = suggestion
+dotnet_naming_rule.private_fields_should_be_camel_with_underscore.symbols = private_fields
+dotnet_naming_rule.private_fields_should_be_camel_with_underscore.style = camel_with_underscore
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+dotnet_naming_style.camel_with_underscore.capitalization = camel_case
+dotnet_naming_style.camel_with_underscore.required_prefix = _
+
+# Newlines & braces
+csharp_new_line_before_open_brace = all

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup>
+    <!-- C# version pour tous les projets -->
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+
+    <!-- Confort multi-TFM -->
+    <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
- Added Directory.Build.props to set a consistent C# language version (latest), enable nullable, and centralize common properties.
- Added .editorconfig to enforce consistent code style (file-scoped namespaces, usings ordering, naming conventions).
- Added .gitattributes to normalize line endings across platforms.
- Updated FastCharts.Wpf.csproj to remove manual inclusion of Themes/Generic.xaml.