### PR TITLE
feat(solution): add FastCharts.Core and FastCharts.Rendering.Skia skeleton projects; wire references

### DIFF
--- a/FastCharts.Core/Abstractions/IAnnotation.cs
+++ b/FastCharts.Core/Abstractions/IAnnotation.cs
@@ -1,0 +1,3 @@
+namespace FastCharts.Core.Abstractions;
+
+public interface IAnnotation { }

--- a/FastCharts.Core/Abstractions/IAxis.cs
+++ b/FastCharts.Core/Abstractions/IAxis.cs
@@ -1,0 +1,12 @@
+using FastCharts.Core.Primitives;
+
+namespace FastCharts.Core.Abstractions;
+
+public interface IAxis<T>
+{
+    IScale<T> Scale { get; }
+    ITicker<T> Ticker { get; }
+    FRange DataRange { get; set; }
+    FRange VisibleRange { get; set; }
+    string? LabelFormat { get; set; }
+}

--- a/FastCharts.Core/Abstractions/IChartModel.cs
+++ b/FastCharts.Core/Abstractions/IChartModel.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace FastCharts.Core.Abstractions;
+
+public interface IChartModel
+{
+    IReadOnlyList<object> Axes { get; }   // kept loose for now; we’ll tighten later
+    IReadOnlyList<object> Series { get; } // idem
+}

--- a/FastCharts.Core/Abstractions/IDownsampler.cs
+++ b/FastCharts.Core/Abstractions/IDownsampler.cs
@@ -1,0 +1,3 @@
+namespace FastCharts.Core.Abstractions;
+
+public interface IDownsampler { }

--- a/FastCharts.Core/Abstractions/IHitTester.cs
+++ b/FastCharts.Core/Abstractions/IHitTester.cs
@@ -1,0 +1,3 @@
+namespace FastCharts.Core.Abstractions;
+
+public interface IHitTester { }

--- a/FastCharts.Core/Abstractions/IPainter.cs
+++ b/FastCharts.Core/Abstractions/IPainter.cs
@@ -1,0 +1,3 @@
+namespace FastCharts.Core.Abstractions;
+
+public interface IPainter { }

--- a/FastCharts.Core/Abstractions/IRenderer.cs
+++ b/FastCharts.Core/Abstractions/IRenderer.cs
@@ -1,0 +1,3 @@
+namespace FastCharts.Core.Abstractions;
+
+public interface IRenderer { }

--- a/FastCharts.Core/Abstractions/IScale.cs
+++ b/FastCharts.Core/Abstractions/IScale.cs
@@ -1,0 +1,7 @@
+namespace FastCharts.Core.Abstractions;
+
+public interface IScale<T>
+{
+    double ToPixels(T value);
+    T FromPixels(double px);
+}

--- a/FastCharts.Core/Abstractions/ISeries.cs
+++ b/FastCharts.Core/Abstractions/ISeries.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace FastCharts.Core.Abstractions;
+
+public interface ISeries<TPoint>
+{
+    IReadOnlyList<TPoint> Data { get; }
+}

--- a/FastCharts.Core/Abstractions/ITextMeasurer.cs
+++ b/FastCharts.Core/Abstractions/ITextMeasurer.cs
@@ -1,0 +1,3 @@
+namespace FastCharts.Core.Abstractions;
+
+public interface ITextMeasurer { }

--- a/FastCharts.Core/Abstractions/ITheme.cs
+++ b/FastCharts.Core/Abstractions/ITheme.cs
@@ -1,0 +1,3 @@
+namespace FastCharts.Core.Abstractions;
+
+public interface ITheme { }

--- a/FastCharts.Core/Abstractions/ITicker.cs
+++ b/FastCharts.Core/Abstractions/ITicker.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+using FastCharts.Core.Primitives;
+
+namespace FastCharts.Core.Abstractions;
+
+public interface ITicker<T>
+{
+    IReadOnlyList<T> GetTicks(FRange range, double approxStep);
+}

--- a/FastCharts.Core/FastCharts.Core.csproj
+++ b/FastCharts.Core/FastCharts.Core.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <EnablePackageValidation>false</EnablePackageValidation>
+  </PropertyGroup>
+</Project>

--- a/FastCharts.Core/Primitives/FRange.cs
+++ b/FastCharts.Core/Primitives/FRange.cs
@@ -1,0 +1,11 @@
+namespace FastCharts.Core.Primitives;
+
+public readonly struct FRange
+{
+    public double Min { get; }
+    public double Max { get; }
+    public FRange(double min, double max) { Min = min; Max = max; }
+    public double Size => Max - Min;
+    public bool Contains(double v) => v >= Min && v <= Max;
+    public override string ToString() => $"[{Min}, {Max}]";
+}

--- a/FastCharts.Core/Primitives/Margin.cs
+++ b/FastCharts.Core/Primitives/Margin.cs
@@ -1,0 +1,9 @@
+namespace FastCharts.Core.Primitives;
+
+public readonly struct Margin(double left, double top, double right, double bottom)
+{
+    public double Left { get; } = left;
+    public double Top { get; } = top;
+    public double Right { get; } = right;
+    public double Bottom { get; } = bottom;
+}

--- a/FastCharts.Core/Primitives/PointD.cs
+++ b/FastCharts.Core/Primitives/PointD.cs
@@ -1,0 +1,7 @@
+namespace FastCharts.Core.Primitives;
+
+public readonly struct PointD(double x, double y)
+{
+    public double X { get; } = x;
+    public double Y { get; } = y;
+}

--- a/FastCharts.Core/Primitives/RectD.cs
+++ b/FastCharts.Core/Primitives/RectD.cs
@@ -1,0 +1,9 @@
+namespace FastCharts.Core.Primitives;
+
+public readonly struct RectD(double x, double y, double width, double height)
+{
+    public double X { get; } = x;
+    public double Y { get; } = y;
+    public double Width { get; } = width;
+    public double Height { get; } = height;
+}

--- a/FastCharts.Rendering.Skia/FastCharts.Rendering.Skia.csproj
+++ b/FastCharts.Rendering.Skia/FastCharts.Rendering.Skia.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FastCharts.Core\FastCharts.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/FastCharts.Rendering.Skia/SkiaPainter.cs
+++ b/FastCharts.Rendering.Skia/SkiaPainter.cs
@@ -1,0 +1,5 @@
+using FastCharts.Core.Abstractions;
+
+namespace FastCharts.Rendering.Skia;
+
+public sealed class SkiaPainter : IPainter { }

--- a/FastCharts.Rendering.Skia/SkiaRenderer.cs
+++ b/FastCharts.Rendering.Skia/SkiaRenderer.cs
@@ -1,0 +1,5 @@
+using FastCharts.Core.Abstractions;
+
+namespace FastCharts.Rendering.Skia;
+
+public sealed class SkiaRenderer : IRenderer { }

--- a/FastCharts.Rendering.Skia/SkiaTextMeasurer.cs
+++ b/FastCharts.Rendering.Skia/SkiaTextMeasurer.cs
@@ -1,0 +1,5 @@
+using FastCharts.Core.Abstractions;
+
+namespace FastCharts.Rendering.Skia;
+
+public sealed class SkiaTextMeasurer : ITextMeasurer { }

--- a/FastChartsSolution.sln
+++ b/FastChartsSolution.sln
@@ -10,6 +10,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DemoApp.Net48", "demos\Demo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FastCharts.Tests", "tests\FastCharts.Tests\FastCharts.Tests.csproj", "{44444444-4444-4444-4444-444444444444}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FastCharts.Core", "FastCharts.Core\FastCharts.Core.csproj", "{3D11A7A6-8A87-4015-84B9-14639D27BA57}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FastCharts.Rendering.Skia", "FastCharts.Rendering.Skia\FastCharts.Rendering.Skia.csproj", "{AD12C365-A920-41BD-AC9C-4F54D7204B3A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,8 +36,19 @@ Global
 		{44444444-4444-4444-4444-444444444444}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{44444444-4444-4444-4444-444444444444}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{44444444-4444-4444-4444-444444444444}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3D11A7A6-8A87-4015-84B9-14639D27BA57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3D11A7A6-8A87-4015-84B9-14639D27BA57}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3D11A7A6-8A87-4015-84B9-14639D27BA57}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3D11A7A6-8A87-4015-84B9-14639D27BA57}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AD12C365-A920-41BD-AC9C-4F54D7204B3A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AD12C365-A920-41BD-AC9C-4F54D7204B3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AD12C365-A920-41BD-AC9C-4F54D7204B3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AD12C365-A920-41BD-AC9C-4F54D7204B3A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {97F7890C-60B6-4144-B693-0F284B8C74EE}
 	EndGlobalSection
 EndGlobal

--- a/src/FastCharts.Wpf/FastCharts.Wpf.csproj
+++ b/src/FastCharts.Wpf/FastCharts.Wpf.csproj
@@ -1,4 +1,4 @@
-
+﻿
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <TargetFrameworks>net48;net6.0-windows10.0.19041.0;net8.0-windows10.0.19041.0</TargetFrameworks>
@@ -16,5 +16,8 @@
   <ItemGroup>
     <None Include="..\..\tests\**" Pack="false" Visible="false" />
     <None Include="..\..\demos\**" Pack="false" Visible="false" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\FastCharts.Core\FastCharts.Core.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
We’re introducing the target layered architecture. This PR creates FastCharts.Core for UI-agnostic contracts/primitives and FastCharts.Rendering.Skia as the renderer adapter (stubbed). No functional changes yet—this only prepares the ground for future refactors while keeping the solution compiling.