### PR TITLE
feat(core): add minimal Axis/Scale/Ticker and Viewport scaffolding

### DIFF
--- a/FastCharts.Core/Abstractions/IViewPort.cs
+++ b/FastCharts.Core/Abstractions/IViewPort.cs
@@ -1,0 +1,12 @@
+﻿using FastCharts.Core.Primitives;
+
+namespace FastCharts.Core.Abstractions;
+
+public interface IViewport
+{
+    FRange X { get; }
+    FRange Y { get; }
+    void SetVisible(FRange x, FRange y);
+    void Zoom(double scaleX, double scaleY, PointD pivotData);
+    void Pan(double dxData, double dyData);
+}

--- a/FastCharts.Core/Axes/NumericAxis.cs
+++ b/FastCharts.Core/Axes/NumericAxis.cs
@@ -1,0 +1,28 @@
+﻿using FastCharts.Core.Abstractions;
+using FastCharts.Core.Primitives;
+using FastCharts.Core.Scales;
+using FastCharts.Core.Ticks;
+
+namespace FastCharts.Core.Axes;
+
+public sealed class NumericAxis : IAxis<double>
+{
+    public NumericAxis()
+    {
+        Scale = new LinearScale(0, 1, 0, 1);
+        Ticker = new NumericTicker();
+        DataRange = new FRange(0, 1);
+        VisibleRange = new FRange(0, 1);
+    }
+
+    public IScale<double> Scale { get; private set; }
+    public ITicker<double> Ticker { get; }
+    public FRange DataRange { get; set; }
+    public FRange VisibleRange { get; set; }
+    public string? LabelFormat { get; set; } = "G";
+
+    public void UpdateScale(double pixelMin, double pixelMax)
+    {
+        Scale = new LinearScale(VisibleRange.Min, VisibleRange.Max, pixelMin, pixelMax);
+    }
+}

--- a/FastCharts.Core/Interactivity/ViewPort.cs
+++ b/FastCharts.Core/Interactivity/ViewPort.cs
@@ -1,0 +1,44 @@
+﻿using FastCharts.Core.Abstractions;
+using FastCharts.Core.Primitives;
+
+namespace FastCharts.Core.Interactivity;
+
+public sealed class Viewport : IViewport
+{
+    public Viewport(FRange x, FRange y)
+    {
+        X = x;
+        Y = y;
+    }
+
+    public FRange X { get; private set; }
+    public FRange Y { get; private set; }
+
+    public void SetVisible(FRange x, FRange y)
+    {
+        X = x;
+        Y = y;
+    }
+
+    public void Zoom(double scaleX, double scaleY, PointD pivotData)
+    {
+        var newX = new FRange(
+            pivotData.X - (pivotData.X - X.Min) / scaleX,
+            pivotData.X + (X.Max - pivotData.X) / scaleX
+        );
+        var newY = new FRange(
+            pivotData.Y - (pivotData.Y - Y.Min) / scaleY,
+            pivotData.Y + (Y.Max - pivotData.Y) / scaleY
+        );
+
+        SetVisible(newX, newY);
+    }
+
+    public void Pan(double dxData, double dyData)
+    {
+        SetVisible(
+            new FRange(X.Min + dxData, X.Max + dxData),
+            new FRange(Y.Min + dyData, Y.Max + dyData)
+        );
+    }
+}

--- a/FastCharts.Core/Scales/LinearScale.cs
+++ b/FastCharts.Core/Scales/LinearScale.cs
@@ -1,0 +1,31 @@
+﻿using FastCharts.Core.Abstractions;
+
+namespace FastCharts.Core.Scales;
+
+public sealed class LinearScale : IScale<double>
+{
+    private readonly double _dataMin;
+    private readonly double _dataMax;
+    private readonly double _pixelMin;
+    private readonly double _pixelMax;
+
+    public LinearScale(double dataMin, double dataMax, double pixelMin, double pixelMax)
+    {
+        _dataMin = dataMin;
+        _dataMax = dataMax;
+        _pixelMin = pixelMin;
+        _pixelMax = pixelMax;
+    }
+
+    public double ToPixels(double value)
+    {
+        var t = (value - _dataMin) / (_dataMax - _dataMin);
+        return _pixelMin + t * (_pixelMax - _pixelMin);
+    }
+
+    public double FromPixels(double px)
+    {
+        var t = (px - _pixelMin) / (_pixelMax - _pixelMin);
+        return _dataMin + t * (_dataMax - _dataMin);
+    }
+}

--- a/FastCharts.Core/Ticks/NumericTicker.cs
+++ b/FastCharts.Core/Ticks/NumericTicker.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+
+using FastCharts.Core.Abstractions;
+using FastCharts.Core.Primitives;
+
+namespace FastCharts.Core.Ticks;
+
+public sealed class NumericTicker : ITicker<double>
+{
+    public IReadOnlyList<double> GetTicks(FRange range, double approxStep)
+    {
+        var ticks = new List<double>();
+        if (range.Size <= 0) return ticks;
+
+        // crude step rounding
+        var step = Math.Max(1, Math.Round(approxStep, MidpointRounding.AwayFromZero));
+        var start = Math.Floor(range.Min / step) * step;
+        for (var x = start; x <= range.Max; x += step)
+            ticks.Add(x);
+
+        return ticks;
+    }
+}


### PR DESCRIPTION
Context
We’re laying down the mathematical backbone of FastCharts.Core. This commit introduces a minimal axis/scale/ticker/viewport pipeline, enabling numeric axes and zoom/pan logic. It’s a foundation for later integration with WPF rendering.

Changes

Added LinearScale implementation for double → pixels conversion.

Added NumericTicker to generate numeric ticks over a range.

Added NumericAxis wrapping scale, ticker, and visible/data ranges.

Added Viewport implementation for pan/zoom over X and Y ranges.

Tests

✅ Solution builds successfully.

✅ Existing tests pass.

No new tests yet — scaffolding only.

Risks

Very low: new Core code only, no impact on WPF or demos.

Labels
feat, core