### PR TITLE
feat(core): add ChartModel and LineSeries (data-only) with unit tests

### DIFF
--- a/FastCharts.Core.Tests/ChartModelTests.cs
+++ b/FastCharts.Core.Tests/ChartModelTests.cs
@@ -1,0 +1,51 @@
+﻿using FastCharts.Core.Primitives;
+using FastCharts.Core.Series;
+using FluentAssertions;
+using Xunit;
+
+namespace FastCharts.Core.Tests;
+
+public class ChartModelTests
+{
+    [Fact]
+    public void ChartModel_ShouldStartWithDefaultAxesAndViewport()
+    {
+        var m = new ChartModel();
+        m.Axes.Should().HaveCount(2);
+        m.Series.Should().BeEmpty();
+        m.Viewport.X.Size.Should().Be(1);
+        m.Viewport.Y.Size.Should().Be(1);
+    }
+
+    [Fact]
+    public void AutoFit_ShouldUpdateDataRangesAndViewport()
+    {
+        var m = new ChartModel();
+        m.AddSeries(new LineSeries(new[]
+        {
+            new PointD(0, 0),
+            new PointD(10, 20)
+        }));
+
+        m.XAxis.DataRange.Min.Should().Be(0);
+        m.XAxis.DataRange.Max.Should().Be(10);
+        m.YAxis.DataRange.Min.Should().Be(0);
+        m.YAxis.DataRange.Max.Should().Be(20);
+
+        m.Viewport.X.Min.Should().Be(0);
+        m.Viewport.X.Max.Should().Be(10);
+        m.Viewport.Y.Min.Should().Be(0);
+        m.Viewport.Y.Max.Should().Be(20);
+    }
+
+    [Fact]
+    public void UpdateScales_ShouldMapX0To0AndX100ToWidth()
+    {
+        var m = new ChartModel();
+        m.AddSeries(new LineSeries(new[] { new PointD(0, 0), new PointD(100, 100) }));
+        m.UpdateScales(widthPx: 200, heightPx: 100);
+
+        m.XAxis.Scale.ToPixels(0).Should().Be(0);
+        m.XAxis.Scale.ToPixels(100).Should().Be(200);
+    }
+}

--- a/FastCharts.Core.Tests/LineSeriesTests.cs
+++ b/FastCharts.Core.Tests/LineSeriesTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+
+using FastCharts.Core.Primitives;
+using FastCharts.Core.Series;
+using FluentAssertions;
+using Xunit;
+
+namespace FastCharts.Core.Tests;
+
+public class LineSeriesTests
+{
+    [Fact]
+    public void LineSeries_ShouldExposeDataAndRanges()
+    {
+        var points = new[]
+        {
+            new PointD(0, 10),
+            new PointD(5, -5),
+            new PointD(10, 20)
+        };
+
+        var s = new LineSeries(points) { StrokeThickness = 2 };
+
+        s.IsEmpty.Should().BeFalse();
+        s.Data.Should().HaveCount(3);
+        s.StrokeThickness.Should().Be(2);
+
+        var xr = s.GetXRange();
+        var yr = s.GetYRange();
+
+        xr.Min.Should().Be(0);
+        xr.Max.Should().Be(10);
+        yr.Min.Should().Be(-5);
+        yr.Max.Should().Be(20);
+    }
+
+    [Fact]
+    public void LineSeries_WithNoPoints_ShouldBeEmptyAndZeroRanges()
+    {
+        var s = new LineSeries(Array.Empty<PointD>());
+        s.IsEmpty.Should().BeTrue();
+
+        var xr = s.GetXRange();
+        var yr = s.GetYRange();
+
+        xr.Min.Should().Be(0);
+        xr.Max.Should().Be(0);
+        yr.Min.Should().Be(0);
+        yr.Max.Should().Be(0);
+    }
+}

--- a/FastCharts.Core/ChartModel.cs
+++ b/FastCharts.Core/ChartModel.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Generic;
+
+using FastCharts.Core.Abstractions;
+using FastCharts.Core.Axes;
+using FastCharts.Core.Primitives;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace FastCharts.Core;
+
+public sealed class ChartModel : IChartModel
+{
+    public ChartModel()
+    {
+        XAxis = new NumericAxis();
+        YAxis = new NumericAxis();
+        Viewport = new Interactivity.Viewport(new FRange(0, 1), new FRange(0, 1));
+
+        Series = new ObservableCollection<object>();
+        Axes = new ReadOnlyCollection<object>(new object[] { XAxis, YAxis });
+    }
+
+    public NumericAxis XAxis { get; }
+    public NumericAxis YAxis { get; }
+    public IViewport Viewport { get; }
+    public ObservableCollection<object> Series { get; }
+    public IReadOnlyList<object> Axes { get; }
+
+    // IChartModel (kept loose for now)
+    IReadOnlyList<object> IChartModel.Axes => Axes;
+    IReadOnlyList<object> IChartModel.Series => Series;
+
+    public void AddSeries(object series)
+    {
+        Series.Add(series);
+        AutoFitDataRange();
+    }
+
+    public void ClearSeries()
+    {
+        Series.Clear();
+        XAxis.DataRange = new FRange(0, 1);
+        YAxis.DataRange = new FRange(0, 1);
+        Viewport.SetVisible(XAxis.DataRange, YAxis.DataRange);
+    }
+
+    public void UpdateScales(double widthPx, double heightPx)
+    {
+        XAxis.VisibleRange = Viewport.X;
+        YAxis.VisibleRange = Viewport.Y;
+        XAxis.UpdateScale(0, widthPx);
+        // Y pixels typically grow downward; invert here for convenience
+        YAxis.UpdateScale(heightPx, 0);
+    }
+
+    public void AutoFitDataRange()
+    {
+        var xs = new List<FRange>();
+        var ys = new List<FRange>();
+
+        foreach (var s in Series)
+        {
+            if (s is Series.LineSeries ls && !ls.IsEmpty)
+            {
+                xs.Add(ls.GetXRange());
+                ys.Add(ls.GetYRange());
+            }
+        }
+
+        if (xs.Count == 0 || ys.Count == 0) return;
+
+        var xMin = xs.Min(r => r.Min);
+        var xMax = xs.Max(r => r.Max);
+        var yMin = ys.Min(r => r.Min);
+        var yMax = ys.Max(r => r.Max);
+
+        if (xMin == xMax) { xMin -= 0.5; xMax += 0.5; }
+        if (yMin == yMax) { yMin -= 0.5; yMax += 0.5; }
+
+        XAxis.DataRange = new FRange(xMin, xMax);
+        YAxis.DataRange = new FRange(yMin, yMax);
+        Viewport.SetVisible(XAxis.DataRange, YAxis.DataRange);
+    }
+}

--- a/FastCharts.Core/Series/LineSeries.cs
+++ b/FastCharts.Core/Series/LineSeries.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using FastCharts.Core.Abstractions;
+using FastCharts.Core.Primitives;
+
+namespace FastCharts.Core.Series;
+
+public sealed class LineSeries : ISeries<PointD>
+{
+    private readonly IReadOnlyList<PointD> _data;
+
+    public LineSeries(IEnumerable<PointD> points)
+    {
+        _data = points?.ToArray() ?? Array.Empty<PointD>();
+    }
+
+    public IReadOnlyList<PointD> Data => _data;
+
+    // UI-agnostic style hints
+    public double StrokeThickness { get; set; } = 1.0;
+    public double? StrokeOpacity { get; set; } = 1.0;
+
+    public bool IsEmpty => _data.Count == 0;
+
+    public FRange GetXRange()
+    {
+        if (_data.Count == 0) return new FRange(0, 0);
+        var min = _data.Min(p => p.X);
+        var max = _data.Max(p => p.X);
+        return new FRange(min, max);
+    }
+
+    public FRange GetYRange()
+    {
+        if (_data.Count == 0) return new FRange(0, 0);
+        var min = _data.Min(p => p.Y);
+        var max = _data.Max(p => p.Y);
+        return new FRange(min, max);
+    }
+}


### PR DESCRIPTION
ontext
Introduces the first concrete Core model types. LineSeries holds XY data and simple style hints; ChartModel composes axes, series, and viewport with helpers (AutoFitDataRange, UpdateScales). No WPF code touched.

Changes

Core:

LineSeries (data-only)

ChartModel (composition + helpers)

Tests:

LineSeriesTests

ChartModelTests

Tests

✅ dotnet test passes locally and in CI.

Risks

Low (new types only, no UI changes).

Checklist

 Build passes on all TFMs

 Tests are green

 No change to WPF public API

Labels
feat, core, tests