### PR TITLE
feat(wpf): add FastChart control with ChartModel DP; demo: bind model in .NET 8 app

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,1 +1,0 @@
-name: build

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,7 +28,7 @@ jobs:
         run: dotnet build FastChartsSolution.sln --configuration Release --no-restore /p:EnableWindowsTargeting=true /p:TreatWarningsAsErrors=false
 
       - name: Test
-        run: dotnet test FastChartsSolution.sln --configuration Release --no-build /p:EnableWindowsTargeting=true --collect:"XPlat Code Coverage" --logger "trx;LogFileName=test-results.trx"
+        run: dotnet test FastChartsSolution.sln --configuration Release /p:EnableWindowsTargeting=true --collect:"XPlat Code Coverage" --logger "trx;LogFileName=test-results.trx"
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,14 +2,20 @@ name: .NET CI
 
 on:
   push:
-    branches: [ main, develop, feature/**, feat/**, fix/**, refactor/**, chore/** ]
+    branches: [ main, develop ]
+    tags:
+      - 'v*.*.*'      # optional: allow release/tag builds
   pull_request:
     branches: [ main, develop ]
+
+# optional: cancel older runs for the same PR/branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-test:
     runs-on: windows-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/FastCharts.Core.Tests/FastCharts.Core.Tests.csproj
+++ b/FastCharts.Core.Tests/FastCharts.Core.Tests.csproj
@@ -4,9 +4,12 @@
         <IsPackable>false</IsPackable>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
+        <!-- Ensures NuGet package DLLs (e.g., FluentAssertions) are copied to bin -->
+        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="xunit" Version="2.9.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
@@ -14,6 +17,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\FastCharts.Core\FastCharts.Core.csproj" />
+        <ProjectReference Include="..\FastCharts.Core\FastCharts.Core.csproj" />
     </ItemGroup>
 </Project>

--- a/demos/DemoApp.Net48/MainWindow.xaml
+++ b/demos/DemoApp.Net48/MainWindow.xaml
@@ -1,18 +1,12 @@
-
-<Window x:Class="DemoApp.MainWindow"
+<Window x:Class="DemoApp.Net8.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:charts="clr-namespace:FastCharts.Wpf.Controls;assembly=FastCharts.Wpf"
-        xmlns:axes="clr-namespace:FastCharts.Wpf.Axes;assembly=FastCharts.Wpf"
-        Title="FastCharts Advanced Demo" Height="450" Width="800">
-  <Grid>
-    <charts:FastLineChart Series="{Binding Series}">
-      <charts:FastLineChart.XAxis>
-        <axes:ChartAxis ShowGrid="True" LabelFormat="0.##" DesiredPixelStep="80"/>
-      </charts:FastLineChart.XAxis>
-      <charts:FastLineChart.YAxis>
-        <axes:ChartAxis ShowGrid="True" LabelFormat="0.###" DesiredPixelStep="50"/>
-      </charts:FastLineChart.YAxis>
-    </charts:FastLineChart>
-  </Grid>
+        xmlns:fc="clr-namespace:FastCharts.Wpf.Controls;assembly=FastCharts.Wpf"
+        Title="FastCharts Demo (.NET 8)" Height="450" Width="800">
+    <Grid>
+        <fc:FastChart
+            Margin="16"
+            Background="#111111"
+            Model="{Binding Chart}" />
+    </Grid>
 </Window>

--- a/demos/DemoApp.Net48/MainWindow.xaml.cs
+++ b/demos/DemoApp.Net48/MainWindow.xaml.cs
@@ -1,30 +1,16 @@
-
-using DynamicData;
-using FastCharts.Wpf.Contracts;
-using System;
-using System.Linq;
 using System.Windows;
-using System.Windows.Media;
+
+using DemoApp.Net48.ViewModels;
 
 namespace DemoApp
 {
     public partial class MainWindow : Window
     {
-        public System.Collections.ObjectModel.ReadOnlyObservableCollection<LineSeries> Series { get; }
-        private readonly SourceList<LineSeries> _source = new();
 
         public MainWindow()
         {
-            InitializeComponent();
-            _source.Connect().Bind(out var series).Subscribe();
-            Series = series;
-            int n = 100; var rand = new Random();
-            var xs = Enumerable.Range(0, n).Select(i => (double)i / 100).ToArray();
-            var sine = xs.Select(Math.Sin).ToArray();
-            var noise = xs.Select(_ => rand.NextDouble() * 2 - 1).ToArray();
-            _source.Add(new LineSeries(xs, sine, "Sine") { Stroke = Brushes.SteelBlue, StrokeThickness = 1.0, DrawLines = true, ShowPoints = false });
-            _source.Add(new LineSeries(xs, noise, "Noise") { Stroke = Brushes.OrangeRed, StrokeThickness = 1.0, DrawLines = true, ShowPoints = false });
-            DataContext = this;
+          DataContext = new MainViewModel();
+          ;
         }
     }
 }

--- a/demos/DemoApp.Net48/ViewModels/MainViewModel.cs
+++ b/demos/DemoApp.Net48/ViewModels/MainViewModel.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Linq;
+
+using FastCharts.Core;
+using FastCharts.Core.Primitives;
+using FastCharts.Core.Series;
+
+namespace DemoApp.Net48.ViewModels
+{
+
+    public sealed class MainViewModel
+    {
+        public ChartModel Chart { get; }
+
+        public MainViewModel()
+        {
+            Chart = new ChartModel();
+
+            var points = Enumerable.Range(0, 101)
+                .Select(i => new PointD(i, Math.Sin(i * Math.PI / 20.0)))
+                .ToArray();
+
+            Chart.AddSeries(new LineSeries(points));
+            Chart.UpdateScales(800, 400); // nominal size; real renderer will update on arrange
+        }
+    }
+}

--- a/demos/DemoApp.Net8/MainWindow.xaml
+++ b/demos/DemoApp.Net8/MainWindow.xaml
@@ -1,18 +1,12 @@
-
-<Window x:Class="DemoApp.MainWindow"
+<Window x:Class="DemoApp.Net8.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:charts="clr-namespace:FastCharts.Wpf.Controls;assembly=FastCharts.Wpf"
-        xmlns:axes="clr-namespace:FastCharts.Wpf.Axes;assembly=FastCharts.Wpf"
-        Title="FastCharts Advanced Demo" Height="450" Width="800">
-  <Grid>
-    <charts:FastLineChart Series="{Binding Series}">
-      <charts:FastLineChart.XAxis>
-        <axes:ChartAxis ShowGrid="True" LabelFormat="0.##" DesiredPixelStep="80"/>
-      </charts:FastLineChart.XAxis>
-      <charts:FastLineChart.YAxis>
-        <axes:ChartAxis ShowGrid="True" LabelFormat="0.###" DesiredPixelStep="50"/>
-      </charts:FastLineChart.YAxis>
-    </charts:FastLineChart>
-  </Grid>
+        xmlns:fc="clr-namespace:FastCharts.Wpf.Controls;assembly=FastCharts.Wpf"
+        Title="FastCharts Demo (.NET 8)" Height="450" Width="800">
+    <Grid>
+        <fc:FastChart
+            Margin="16"
+            Background="#111111"
+            Model="{Binding Chart}" />
+    </Grid>
 </Window>

--- a/demos/DemoApp.Net8/MainWindow.xaml.cs
+++ b/demos/DemoApp.Net8/MainWindow.xaml.cs
@@ -1,30 +1,14 @@
-
-using System;
-using System.Linq;
 using System.Windows;
-using System.Windows.Media;
-using DynamicData;
-using FastCharts.Wpf.Contracts;
+using DemoApp.Net8.ViewModels;
 
 namespace DemoApp
 {
     public partial class MainWindow : Window
     {
-        public System.Collections.ObjectModel.ReadOnlyObservableCollection<LineSeries> Series { get; }
-        private readonly SourceList<LineSeries> _source = new();
 
         public MainWindow()
         {
-            InitializeComponent();
-            _source.Connect().Bind(out var series).Subscribe();
-            Series = series;
-            int n=100_000; var rand=new Random();
-            var xs=Enumerable.Range(0,n).Select(i=>(double)i/100).ToArray();
-            var sine=xs.Select(Math.Sin).ToArray();
-            var noise=xs.Select(_=>rand.NextDouble()*2-1).ToArray();
-            _source.Add(new LineSeries(xs,sine,"Sine"){ Stroke=Brushes.SteelBlue, StrokeThickness=1.0, DrawLines=true, ShowPoints=false });
-            _source.Add(new LineSeries(xs,noise,"Noise"){ Stroke=Brushes.OrangeRed, StrokeThickness=1.0, DrawLines=true, ShowPoints=false });
-            DataContext=this;
+            DataContext = new MainViewModel();
         }
     }
 }

--- a/demos/DemoApp.Net8/ViewModels/MainViewModel.cs
+++ b/demos/DemoApp.Net8/ViewModels/MainViewModel.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Linq;
+
+using FastCharts.Core;
+using FastCharts.Core.Primitives;
+using FastCharts.Core.Series;
+
+namespace DemoApp.Net8.ViewModels;
+
+public sealed class MainViewModel
+{
+    public ChartModel Chart { get; }
+
+    public MainViewModel()
+    {
+        Chart = new ChartModel();
+
+        var points = Enumerable.Range(0, 101)
+            .Select(i => new PointD(i, Math.Sin(i * Math.PI / 20.0)))
+            .ToArray();
+
+        Chart.AddSeries(new LineSeries(points));
+        Chart.UpdateScales(800, 400); // nominal size; real renderer will update on arrange
+    }
+}

--- a/src/FastCharts.Wpf/Controls/FastChart.cs
+++ b/src/FastCharts.Wpf/Controls/FastChart.cs
@@ -1,0 +1,30 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+using FastCharts.Core;
+
+namespace FastCharts.Wpf.Controls
+{
+
+    public class FastChart : Control
+    {
+        static FastChart()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(
+                typeof(FastChart),
+                new FrameworkPropertyMetadata(typeof(FastChart)));
+        }
+
+        public ChartModel? Model
+        {
+            get => (ChartModel?)GetValue(ModelProperty);
+            set => SetValue(ModelProperty, value);
+        }
+
+        public static readonly DependencyProperty ModelProperty =
+            DependencyProperty.Register(
+                nameof(Model),
+                typeof(ChartModel),
+                typeof(FastChart),
+                new FrameworkPropertyMetadata(default(ChartModel), FrameworkPropertyMetadataOptions.AffectsRender));
+    }
+}

--- a/src/FastCharts.Wpf/FastCharts.Wpf.csproj
+++ b/src/FastCharts.Wpf/FastCharts.Wpf.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net48;net6.0-windows10.0.19041.0;net8.0-windows10.0.19041.0</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net48'">
     <LangVersion>9.0</LangVersion>

--- a/src/FastCharts.Wpf/Themes/FastChart.xaml
+++ b/src/FastCharts.Wpf/Themes/FastChart.xaml
@@ -1,0 +1,25 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:fc="clr-namespace:FastCharts.Wpf.Controls">
+
+    <Style TargetType="{x:Type fc:FastChart}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type fc:FastChart}">
+                    <Border Background="{TemplateBinding Background}">
+                        <Grid>
+                            <!-- placeholder until the renderer is wired -->
+                            <TextBlock
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Opacity="0.5"
+                                Text="FastCharts (renderer not wired yet)"/>
+                        </Grid>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/src/FastCharts.Wpf/Themes/Generic.xaml
+++ b/src/FastCharts.Wpf/Themes/Generic.xaml
@@ -11,4 +11,8 @@
       </Setter.Value>
     </Setter>
   </Style>
+  
+  <ResourceDictionary.MergedDictionaries>
+    <ResourceDictionary Source="FastChart.xaml"/>
+  </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>

--- a/tests/FastCharts.Tests/DownsamplerTests.cs
+++ b/tests/FastCharts.Tests/DownsamplerTests.cs
@@ -1,6 +1,7 @@
-
 using System.Linq;
+
 using FastCharts.Wpf.Downsampling;
+
 using Xunit;
 
 public class DownsamplerTests

--- a/tests/FastCharts.Tests/FastCharts.Tests.csproj
+++ b/tests/FastCharts.Tests/FastCharts.Tests.csproj
@@ -13,6 +13,9 @@
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="coverlet.collector" Version="6.0.0" />
+
+        <!-- ✅ Explicit Newtonsoft.Json dependency so testhost can load it -->
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/FastCharts.Tests/FastCharts.Tests.csproj
+++ b/tests/FastCharts.Tests/FastCharts.Tests.csproj
@@ -1,17 +1,22 @@
-
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\FastCharts.Wpf\FastCharts.Wpf.csproj" />
-  </ItemGroup>
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <!-- ensure packages like FluentAssertions are copied to bin -->
+        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\FastCharts.Core\FastCharts.Core.csproj" />
+      <ProjectReference Include="..\..\src\FastCharts.Wpf\FastCharts.Wpf.csproj" />
+    </ItemGroup>
 </Project>

--- a/tests/FastCharts.Tests/FastCharts.Tests.csproj
+++ b/tests/FastCharts.Tests/FastCharts.Tests.csproj
@@ -1,25 +1,30 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <!-- Target Windows TFM since this test references FastCharts.Wpf -->
+        <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+        <UseWPF>true</UseWPF>
+
         <IsPackable>false</IsPackable>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
-        <!-- ensure packages like FluentAssertions are copied to bin -->
+
+        <!-- Ensure NuGet packages are copied into bin for the testhost -->
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="xunit" Version="2.9.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-        <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="coverlet.collector" Version="6.0.0" />
-
-        <!-- ✅ Explicit Newtonsoft.Json dependency so testhost can load it -->
+        <!-- keep only if your tests actually use it -->
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\FastCharts.Core\FastCharts.Core.csproj" />
-      <ProjectReference Include="..\..\src\FastCharts.Wpf\FastCharts.Wpf.csproj" />
+        <ProjectReference Include="..\..\src\FastCharts.Wpf\FastCharts.Wpf.csproj" />
+        <ProjectReference Include="..\..\src\FastCharts.Core\FastCharts.Core.csproj" />
     </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Context
Wire WPF to Core by introducing a FastChart control that accepts a ChartModel. Rendering is not implemented yet—this is plumbing only to validate bindings and prepare for the renderer.

Changes

FastCharts.Wpf:

New FastChart control (DependencyProperty: Model).

Default style in Themes/Generic.xaml (placeholder content).

Ensure ThemeInfo present.

DemoApp.Net8:

MainViewModel builds a sample ChartModel + LineSeries.

MainWindow binds <fc:FastChart Model="{Binding Chart}" />.

(Optional) DemoApp.Net48: same wiring.

Tests

✅ Solution builds.

✅ Existing unit tests still green.

CI unchanged (runs Restore/Build/Test on Windows).

Risks

Low: UI scaffold only; no drawing paths yet.

Checklist

 Build passes on CI

 Demo launches and displays placeholder template

 No rendering code added

Labels
feat, wpf, demo