### PR TITLE
feat(wpf): host Skia in FastChart and draw minimal LineSeries; sync scales on size and paint

### DIFF
--- a/src/FastCharts.Wpf/Controls/FastChart.cs
+++ b/src/FastCharts.Wpf/Controls/FastChart.cs
@@ -1,11 +1,17 @@
 ﻿using System.Collections.Specialized;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using FastCharts.Core;
+using FastCharts.Core.Series;
+using SkiaSharp;
+using SkiaSharp.Views.Desktop;
+using SkiaSharp.Views.WPF;
 
 namespace FastCharts.Wpf.Controls
 {
 
+    [TemplatePart(Name = "PART_Skia", Type = typeof(SKElement))]
     public class FastChart : Control
     {
         static FastChart()
@@ -19,6 +25,7 @@ namespace FastCharts.Wpf.Controls
         {
             Loaded += OnLoaded;
             SizeChanged += OnSizeChanged;
+            Unloaded += OnUnloaded;
         }
 
         public ChartModel? Model
@@ -45,34 +52,40 @@ namespace FastCharts.Wpf.Controls
             ctrl.RefreshScalesAndRedraw();
         }
 
+        private SKElement? _skia;
+
+        public override void OnApplyTemplate()
+        {
+            base.OnApplyTemplate();
+
+            if (_skia != null)
+            {
+                _skia.PaintSurface -= OnSkiaPaint;
+            }
+
+            _skia = GetTemplateChild("PART_Skia") as SKElement;
+            if (_skia != null)
+            {
+                _skia.PaintSurface += OnSkiaPaint;
+                _skia.IgnorePixelScaling = false; // respect DPI
+            }
+
+            RefreshScalesAndRedraw();
+        }
+
         private void OnLoaded(object? sender, RoutedEventArgs e) => RefreshScalesAndRedraw();
 
-        private void OnSizeChanged(object sender, SizeChangedEventArgs e) => RefreshScalesAndRedraw();
-
-        private void RefreshScalesAndRedraw()
+        private void OnUnloaded(object? sender, RoutedEventArgs e)
         {
-            if (Model is null)
+            if (_skia != null)
             {
-                InvalidateVisual();
-                return;
+                _skia.PaintSurface -= OnSkiaPaint;
             }
 
-            var w = ActualWidth;
-            var h = ActualHeight;
-
-            // Guard during initial measure/arrange
-            if (double.IsNaN(w) || double.IsNaN(h) || w <= 0 || h <= 0)
-            {
-                InvalidateVisual();
-                return;
-            }
-
-            // Ensure ranges & scales are consistent with current size
-            Model.AutoFitDataRange();
-            Model.UpdateScales(w, h);
-
-            InvalidateVisual(); // renderer will hook here in a later step
+            DetachFromModel(Model);
         }
+
+        private void OnSizeChanged(object sender, SizeChangedEventArgs e) => RefreshScalesAndRedraw();
 
         private void AttachToModel(ChartModel? model)
         {
@@ -91,6 +104,80 @@ namespace FastCharts.Wpf.Controls
             if (Model is null) return;
             Model.AutoFitDataRange();
             RefreshScalesAndRedraw();
+        }
+
+        private void RefreshScalesAndRedraw()
+        {
+            if (Model is null)
+            {
+                InvalidateVisual();
+                _skia?.InvalidateVisual();
+                return;
+            }
+
+            var w = ActualWidth;
+            var h = ActualHeight;
+            if (double.IsNaN(w) || double.IsNaN(h) || w <= 0 || h <= 0)
+            {
+                InvalidateVisual();
+                _skia?.InvalidateVisual();
+                return;
+            }
+
+            // Keep scales in sync with current layout size (DIPs).
+            Model.UpdateScales(w, h);
+
+            // Ask Skia to repaint
+            _skia?.InvalidateVisual();
+        }
+
+        private void OnSkiaPaint(object? sender, SKPaintSurfaceEventArgs e)
+        {
+            // Canvas in device pixels:
+            var canvas = e.Surface.Canvas;
+            var widthPx = e.Info.Width;
+            var heightPx = e.Info.Height;
+
+            // (Optional) Re-sync scales to exact pixel size to avoid off-by-DPI effects.
+            if (Model != null)
+                Model.UpdateScales(widthPx, heightPx);
+
+            // Clear background (transparent → Border’s Background shows through).
+            canvas.Clear(SKColors.Transparent);
+
+            if (Model == null) return;
+
+            // Draw the first LineSeries, if any.
+            var ls = Model.Series.OfType<LineSeries>().FirstOrDefault();
+            if (ls == null || ls.IsEmpty) return;
+
+            using var paint = new SKPaint
+            {
+                IsAntialias = true,
+                Style = SKPaintStyle.Stroke,
+                StrokeWidth = (float)ls.StrokeThickness,
+                Color = new SKColor(0x33, 0x99, 0xFF) // minimal color; we’ll theme later
+            };
+
+            using var path = new SKPath();
+            bool started = false;
+
+            foreach (var p in ls.Data)
+            {
+                var x = (float)Model.XAxis.Scale.ToPixels(p.X);
+                var y = (float)Model.YAxis.Scale.ToPixels(p.Y);
+                if (!started)
+                {
+                    path.MoveTo(x, y);
+                    started = true;
+                }
+                else
+                {
+                    path.LineTo(x, y);
+                }
+            }
+
+            canvas.DrawPath(path, paint);
         }
     }
 }

--- a/src/FastCharts.Wpf/FastCharts.Wpf.csproj
+++ b/src/FastCharts.Wpf/FastCharts.Wpf.csproj
@@ -1,24 +1,25 @@
-﻿
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
-  <PropertyGroup>
-    <TargetFrameworks>net48;net6.0-windows10.0.19041.0;net8.0-windows10.0.19041.0</TargetFrameworks>
-    <UseWPF>true</UseWPF>
-    <Nullable>enable</Nullable>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net48'">
-    <LangVersion>9.0</LangVersion>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="DynamicData" Version="8.*" />
-    <PackageReference Include="ReactiveUI" Version="19.*" />
-    <PackageReference Include="System.Reactive" Version="6.*" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\tests\**" Pack="false" Visible="false" />
-    <None Include="..\..\demos\**" Pack="false" Visible="false" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\FastCharts.Core\FastCharts.Core.csproj" />
-  </ItemGroup>
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+    <PropertyGroup>
+        <TargetFrameworks>net48;net6.0-windows10.0.19041.0;net8.0-windows10.0.19041.0</TargetFrameworks>
+        <UseWPF>true</UseWPF>
+        <Nullable>enable</Nullable>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(TargetFramework)' == 'net48'">
+        <LangVersion>9.0</LangVersion>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="DynamicData" Version="8.*"/>
+        <PackageReference Include="ReactiveUI" Version="19.*"/>
+        <PackageReference Include="System.Reactive" Version="6.*"/>
+        <PackageReference Include="SkiaSharp" Version="2.88.6"/>
+        <PackageReference Include="SkiaSharp.Views.WPF" Version="2.88.6"/>
+    </ItemGroup>
+    <ItemGroup>
+        <None Include="..\..\tests\**" Pack="false" Visible="false"/>
+        <None Include="..\..\demos\**" Pack="false" Visible="false"/>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\FastCharts.Core\FastCharts.Core.csproj"/>
+    </ItemGroup>
 </Project>

--- a/src/FastCharts.Wpf/Themes/FastChart.xaml
+++ b/src/FastCharts.Wpf/Themes/FastChart.xaml
@@ -1,21 +1,18 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:fc="clr-namespace:FastCharts.Wpf.Controls">
+    xmlns:fc="clr-namespace:FastCharts.Wpf.Controls"
+    xmlns:skia="clr-namespace:SkiaSharp.Views.WPF;assembly=SkiaSharp.Views.WPF">
 
     <Style TargetType="{x:Type fc:FastChart}">
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type fc:FastChart}">
                     <Border Background="{TemplateBinding Background}">
-                        <Grid>
-                            <!-- placeholder until the renderer is wired -->
-                            <TextBlock
-                                HorizontalAlignment="Center"
-                                VerticalAlignment="Center"
-                                Opacity="0.5"
-                                Text="FastCharts (renderer not wired yet)"/>
-                        </Grid>
+                        <!-- Skia host surface -->
+                        <skia:SKElement x:Name="PART_Skia"
+                                        HorizontalAlignment="Stretch"
+                                        VerticalAlignment="Stretch" />
                     </Border>
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
Context
First visual output: embed a Skia surface (SKElement) in the FastChart template and render the first LineSeries using Core scales. Keeps things minimal and reversible.

Changes

FastCharts.Wpf.csproj: add SkiaSharp + SkiaSharp.Views.WPF.

Themes/FastChart.xaml: replace placeholder with SKElement (PART_Skia).

FastChart.cs: template hookup, PaintSurface handler, translate data→pixels via ChartModel axes, redraw on size/model changes.

Tests

✅ Solution builds; unit tests unaffected and still green (UI only).

Manual run of demos should display a simple line.

Risks

Low: introduces Skia dependency in WPF only; Rendering project remains untouched.

Checklist

 CI green

 Demo shows a line

 No regressions in tests

Labels
feat, wpf, rendering