### PR TITLE
feat(rendering): add grid lines and use Core theme; expose default LightTheme on ChartModel

### DIFF
--- a/src/FastCharts.Core/Abstractions/ITheme.cs
+++ b/src/FastCharts.Core/Abstractions/ITheme.cs
@@ -1,3 +1,15 @@
+using FastCharts.Core.Primitives;
+
 namespace FastCharts.Core.Abstractions;
 
-public interface ITheme { }
+public interface ITheme
+{
+    ColorRgba AxisColor { get; }
+    ColorRgba GridColor { get; }
+    ColorRgba LabelColor { get; }
+    double AxisThickness { get; }
+    double GridThickness { get; }
+    double TickLength { get; }
+    double LabelTextSize { get; }
+    ColorRgba PrimarySeriesColor { get; }
+}

--- a/src/FastCharts.Core/ChartModel.cs
+++ b/src/FastCharts.Core/ChartModel.cs
@@ -6,6 +6,8 @@ using FastCharts.Core.Primitives;
 using System.Collections.ObjectModel;
 using System.Linq;
 
+using FastCharts.Core.Themes.BuiltIn;
+
 namespace FastCharts.Core;
 
 public sealed class ChartModel : IChartModel
@@ -20,6 +22,7 @@ public sealed class ChartModel : IChartModel
         Axes = new ReadOnlyCollection<object>(new object[] { XAxis, YAxis });
     }
 
+    public ITheme Theme { get; set; } = new LightTheme();
     public NumericAxis XAxis { get; }
     public NumericAxis YAxis { get; }
     public IViewport Viewport { get; }

--- a/src/FastCharts.Core/Primitives/ColorRgba.cs
+++ b/src/FastCharts.Core/Primitives/ColorRgba.cs
@@ -1,0 +1,7 @@
+﻿namespace FastCharts.Core.Primitives;
+
+public readonly struct ColorRgba
+{
+    public readonly byte R, G, B, A;
+    public ColorRgba(byte r, byte g, byte b, byte a = 255) { R = r; G = g; B = b; A = a; }
+}

--- a/src/FastCharts.Core/Themes/BuiltIn/LightTheme.cs
+++ b/src/FastCharts.Core/Themes/BuiltIn/LightTheme.cs
@@ -1,0 +1,16 @@
+﻿using FastCharts.Core.Abstractions;
+using FastCharts.Core.Primitives;
+
+namespace FastCharts.Core.Themes.BuiltIn;
+
+public sealed class LightTheme : ITheme
+{
+    public ColorRgba AxisColor => new(153, 153, 153, 255);   // #999
+    public ColorRgba GridColor => new(80, 80, 80, 64);       // subtle grid
+    public ColorRgba LabelColor => new(136, 136, 136, 255);  // #888
+    public double AxisThickness => 1;
+    public double GridThickness => 1;
+    public double TickLength => 5;
+    public double LabelTextSize => 12;
+    public ColorRgba PrimarySeriesColor => new(51, 153, 255, 255); // blue
+}

--- a/src/FastCharts.Rendering.Skia/SkiaChartRenderer.cs
+++ b/src/FastCharts.Rendering.Skia/SkiaChartRenderer.cs
@@ -1,142 +1,188 @@
 using System.Linq;
-
 using FastCharts.Core;
 using FastCharts.Core.Abstractions;
 using FastCharts.Core.Series;
-
 using SkiaSharp;
 
 namespace FastCharts.Rendering.Skia
 {
+    /// <summary>
+    /// Minimal Skia renderer: draws axes (ticks + labels), grid, then the first LineSeries.
+    /// Uses the model's Theme for colors/sizes.
+    /// </summary>
     public sealed class SkiaChartRenderer : IRenderer<SKCanvas>
     {
-        // Simple plot margins (px) — later we’ll make this themable
-        private const float Left = 48f;
-        private const float Right = 16f;
-        private const float Top = 16f;
+        // Plot margins (pixels)
+        private const float Left   = 48f;
+        private const float Right  = 16f;
+        private const float Top    = 16f;
         private const float Bottom = 36f;
 
         public void Render(ChartModel model, SKCanvas canvas, int pixelWidth, int pixelHeight)
         {
             if (model == null || canvas == null) return;
 
-            // Full-surface clear (let WPF Border show Background)
+            // Clear to transparent so the WPF Border's Background shows through
             canvas.Clear(SKColors.Transparent);
 
-            // Plot area
-            var plotW = (int)System.Math.Max(0, pixelWidth - (Left + Right));
+            // Compute plot area (the inner rectangle where data is drawn)
+            var plotW = (int)System.Math.Max(0, pixelWidth  - (Left + Right));
             var plotH = (int)System.Math.Max(0, pixelHeight - (Top + Bottom));
+            if (plotW <= 0 || plotH <= 0)
+                return;
 
-            // Keep scales exact for plot area size (not full control size)
+            // Keep scales exact for the *plot* size (not the full control size)
             model.UpdateScales(plotW, plotH);
 
-            // Draw axes (ticks + labels) around plot area
-            DrawAxes(canvas, model, pixelWidth, pixelHeight, plotW, plotH);
+            // Prepare paints from theme
+            var theme = model.Theme;
 
-            // Draw first LineSeries inside plot area
-            var ls = model.Series.OfType<LineSeries>().FirstOrDefault();
-            if (ls is null || ls.IsEmpty) return;
-
-            canvas.Save();
-            canvas.Translate(Left, Top);
-
-            using var paint = new SKPaint
-            {
-                IsAntialias = true,
-                Style = SKPaintStyle.Stroke,
-                StrokeWidth = (float)ls.StrokeThickness,
-                Color = new SKColor(0x33, 0x99, 0xFF)
-            };
-
-            using var path = new SKPath();
-            bool started = false;
-
-            foreach (var p in ls.Data)
-            {
-                var x = (float)model.XAxis.Scale.ToPixels(p.X);
-                var y = (float)model.YAxis.Scale.ToPixels(p.Y);
-                if (!started) { path.MoveTo(x, y); started = true; }
-                else { path.LineTo(x, y); }
-            }
-
-            canvas.DrawPath(path, paint);
-            canvas.Restore();
-        }
-
-        private static void DrawAxes(SKCanvas canvas, ChartModel model,
-                                     int surfaceW, int surfaceH, int plotW, int plotH)
-        {
-            // Axis lines
             using var axisPaint = new SKPaint
             {
                 IsAntialias = true,
                 Style = SKPaintStyle.Stroke,
-                Color = new SKColor(0x99, 0x99, 0x99),
-                StrokeWidth = 1
+                Color = new SKColor(theme.AxisColor.R, theme.AxisColor.G, theme.AxisColor.B, theme.AxisColor.A),
+                StrokeWidth = (float)theme.AxisThickness
             };
 
-            // X axis (bottom)
-            var x0 = Left;
-            var x1 = surfaceW - Right;
-            var yBase = surfaceH - Bottom;
-            canvas.DrawLine(x0, yBase, x1, yBase, axisPaint);
-
-            // Y axis (left)
-            var y0 = Top;
-            var y1 = surfaceH - Bottom;
-            var xBase = Left;
-            canvas.DrawLine(xBase, y0, xBase, y1, axisPaint);
-
-            // Ticks & labels
             using var tickPaint = new SKPaint
             {
                 IsAntialias = true,
                 Style = SKPaintStyle.Stroke,
                 Color = axisPaint.Color,
-                StrokeWidth = 1
+                StrokeWidth = (float)theme.AxisThickness
             };
+
             using var textPaint = new SKPaint
             {
                 IsAntialias = true,
-                Color = new SKColor(0x88, 0x88, 0x88),
-                TextSize = 12
+                Color = new SKColor(theme.LabelColor.R, theme.LabelColor.G, theme.LabelColor.B, theme.LabelColor.A),
+                TextSize = (float)theme.LabelTextSize
             };
 
-            // X ticks (use approx 80px step)
-            var approxXStepInPx = 80.0;
-            var xDataPerPx = (model.XAxis.VisibleRange.Size) / System.Math.Max(1.0, plotW);
-            var approxXStepData = approxXStepInPx * xDataPerPx;
+            using var gridPaint = new SKPaint
+            {
+                IsAntialias = false,
+                Style = SKPaintStyle.Stroke,
+                Color = new SKColor(theme.GridColor.R, theme.GridColor.G, theme.GridColor.B, theme.GridColor.A),
+                StrokeWidth = (float)theme.GridThickness
+            };
+
+            // Axis baselines (in surface coordinates)
+            var x0 = Left;
+            var x1 = pixelWidth - Right;
+            var yBase = pixelHeight - Bottom;
+
+            var y0 = Top;
+            var y1 = pixelHeight - Bottom;
+            var xBase = Left;
+
+            // Draw axis lines
+            canvas.DrawLine(x0, yBase, x1, yBase, axisPaint); // X axis
+            canvas.DrawLine(xBase, y0, xBase, y1, axisPaint); // Y axis
+
+            // Compute ticks (approx. pixel step → data step)
+            var xDataPerPx = model.XAxis.VisibleRange.Size / System.Math.Max(1.0, plotW);
+            var yDataPerPx = model.YAxis.VisibleRange.Size / System.Math.Max(1.0, plotH);
+
+            var approxXStepData = 80.0 * xDataPerPx; // ~80 px between x ticks
+            var approxYStepData = 50.0 * yDataPerPx; // ~50 px between y ticks
 
             var xTicks = model.XAxis.Ticker.GetTicks(model.XAxis.VisibleRange, approxXStepData);
+            var yTicks = model.YAxis.Ticker.GetTicks(model.YAxis.VisibleRange, approxYStepData);
+
+            // Draw grid inside plot area
+            canvas.Save();
+            canvas.Translate(Left, Top);
+
+            // Vertical grid lines at X ticks
+            foreach (var t in xTicks)
+            {
+                var x = (float)model.XAxis.Scale.ToPixels(t);
+                canvas.DrawLine(x + 0.5f, 0, x + 0.5f, plotH, gridPaint);
+            }
+
+            // Horizontal grid lines at Y ticks
+            foreach (var t in yTicks)
+            {
+                var y = (float)model.YAxis.Scale.ToPixels(t);
+                canvas.DrawLine(0, y + 0.5f, plotW, y + 0.5f, gridPaint);
+            }
+
+            canvas.Restore();
+
+            // Draw ticks and labels (surface coordinates)
+            var tickLen = (float)theme.TickLength;
+
+            // X-axis ticks & labels
             foreach (var t in xTicks)
             {
                 var px = (float)model.XAxis.Scale.ToPixels(t) + Left;
+
                 // tick
-                canvas.DrawLine(px, yBase, px, yBase + 5, tickPaint);
+                canvas.DrawLine(px, yBase, px, yBase + tickLen, tickPaint);
 
                 // label
                 var label = t.ToString(model.XAxis.LabelFormat ?? "G");
                 var w = textPaint.MeasureText(label);
-                canvas.DrawText(label, px - w / 2f, yBase + 18, textPaint);
+                // place a bit below the ticks (3px padding)
+                canvas.DrawText(label, px - w / 2f, yBase + tickLen + 3 + textPaint.TextSize, textPaint);
             }
 
-            // Y ticks (use approx 50px step)
-            var approxYStepInPx = 50.0;
-            var yDataPerPx = (model.YAxis.VisibleRange.Size) / System.Math.Max(1.0, plotH);
-            var approxYStepData = approxYStepInPx * yDataPerPx;
-
-            var yTicks = model.YAxis.Ticker.GetTicks(model.YAxis.VisibleRange, approxYStepData);
+            // Y-axis ticks & labels
             foreach (var t in yTicks)
             {
                 var py = (float)model.YAxis.Scale.ToPixels(t) + Top;
-                // tick
-                canvas.DrawLine(xBase - 5, py, xBase, py, tickPaint);
 
-                // label (right-aligned to left margin - 6px)
+                // tick
+                canvas.DrawLine(xBase - tickLen, py, xBase, py, tickPaint);
+
+                // label (right-aligned to left of axis, ~6px padding; +4 for baseline tweak)
                 var label = t.ToString(model.YAxis.LabelFormat ?? "G");
                 var w = textPaint.MeasureText(label);
-                canvas.DrawText(label, xBase - 6 - w, py + 4, textPaint);
+                canvas.DrawText(label, xBase - tickLen - 6 - w, py + 4, textPaint);
             }
+
+            // Draw the first LineSeries in the plot area
+            var ls = model.Series.OfType<LineSeries>().FirstOrDefault();
+            if (ls == null || ls.IsEmpty) return;
+
+            using var seriesPaint = new SKPaint
+            {
+                IsAntialias = true,
+                Style = SKPaintStyle.Stroke,
+                StrokeWidth = (float)ls.StrokeThickness,
+                Color = new SKColor(
+                    model.Theme.PrimarySeriesColor.R,
+                    model.Theme.PrimarySeriesColor.G,
+                    model.Theme.PrimarySeriesColor.B,
+                    model.Theme.PrimarySeriesColor.A)
+            };
+
+            using var path = new SKPath();
+            bool started = false;
+
+            canvas.Save();
+            canvas.Translate(Left, Top);
+
+            foreach (var p in ls.Data)
+            {
+                var x = (float)model.XAxis.Scale.ToPixels(p.X);
+                var y = (float)model.YAxis.Scale.ToPixels(p.Y);
+
+                if (!started)
+                {
+                    path.MoveTo(x, y);
+                    started = true;
+                }
+                else
+                {
+                    path.LineTo(x, y);
+                }
+            }
+
+            canvas.DrawPath(path, seriesPaint);
+            canvas.Restore();
         }
     }
 }


### PR DESCRIPTION
Summary
This PR introduces a tiny, UI-agnostic theme in Core (colors/sizes as plain data) and updates the Skia renderer to draw grid lines and use theme-driven colors/metrics. No XAML changes; WPF keeps your current Themes organization.

Changes

Core

ColorRgba primitive.

ITheme contract.

Built-in LightTheme.

ChartModel.Theme (defaults to LightTheme).

Rendering.Skia

Draw vertical/horizontal grid in the plot area.

Use theme for axis/tick/label/series colors and sizes.

Keep existing margins and tick generation.

Screenshots

Optional: add a before/after if you want.

Testing

Build + existing unit tests remain green.

Demos: the sine wave now shows axes + subtle grid (no code-behind changes required).

Backward compatibility

No breaking changes. ChartModel gets a new Theme property with a sensible default.

Checklist

 CI green

 Demo renders grid + line

 No hardcoded colors left in SkiaChartRenderer