### PR TITLE
feat(theme): add PlotBackgroundColor; Skia fills plot area (Light=white, Dark=near-black)

### DIFF
--- a/demos/DemoApp.Net48/MainWindow.xaml
+++ b/demos/DemoApp.Net48/MainWindow.xaml
@@ -8,6 +8,5 @@
         Title="MainWindow" Height="450" Width="800">
     <controls:FastChart
         Margin="16"
-        Background="#111111"
         Model="{Binding Chart}" />
 </Window>

--- a/demos/DemoApp.Net48/ViewModels/MainViewModel.cs
+++ b/demos/DemoApp.Net48/ViewModels/MainViewModel.cs
@@ -20,7 +20,7 @@ namespace DemoApp.Net48.ViewModels
             var points = Enumerable.Range(0, 101)
                 .Select(i => new PointD(i, Math.Sin(i * Math.PI / 20.0)))
                 .ToArray();
-            
+            Chart.Theme = new DarkTheme();
             Chart.AddSeries(new LineSeries(points));
             Chart.UpdateScales(800, 400); // nominal size; real renderer will update on arrange
         }

--- a/demos/DemoApp.Net8/MainWindow.xaml
+++ b/demos/DemoApp.Net8/MainWindow.xaml
@@ -8,6 +8,5 @@
         Title="MainWindow" Height="450" Width="800">
     <controls:FastChart
         Margin="16"
-        Background="#111111"
         Model="{Binding Chart}" />
 </Window>

--- a/src/FastCharts.Core/Abstractions/ITheme.cs
+++ b/src/FastCharts.Core/Abstractions/ITheme.cs
@@ -15,5 +15,8 @@ public interface ITheme
     double LabelTextSize { get; }
 
     ColorRgba PrimarySeriesColor { get; }
-    IReadOnlyList<ColorRgba> SeriesPalette { get; } // NEW
+    IReadOnlyList<ColorRgba> SeriesPalette { get; } 
+    ColorRgba PlotBackgroundColor { get; }
+    
+    ColorRgba SurfaceBackgroundColor { get; }
 }

--- a/src/FastCharts.Core/Themes/BuiltIn/DarkTheme.cs
+++ b/src/FastCharts.Core/Themes/BuiltIn/DarkTheme.cs
@@ -27,4 +27,7 @@ public sealed class DarkTheme : ITheme
         new(155, 120, 255), // purple
         new(255, 200,  60), // yellow
     };
+    
+    public ColorRgba PlotBackgroundColor => new(18, 18, 18); // near-black
+    public ColorRgba SurfaceBackgroundColor => new(18, 18, 18);
 }

--- a/src/FastCharts.Core/Themes/BuiltIn/LightTheme.cs
+++ b/src/FastCharts.Core/Themes/BuiltIn/LightTheme.cs
@@ -26,4 +26,7 @@ public sealed class LightTheme : ITheme
         new(155, 120, 255), // purple
         new(255, 200,  60), // yellow
     };
+    
+    public ColorRgba PlotBackgroundColor => new(255, 255, 255); // white
+    public ColorRgba SurfaceBackgroundColor => new(255, 255, 255);
 }

--- a/src/FastCharts.Rendering.Skia/SkiaChartRenderer.cs
+++ b/src/FastCharts.Rendering.Skia/SkiaChartRenderer.cs
@@ -21,9 +21,15 @@ namespace FastCharts.Rendering.Skia
         public void Render(ChartModel model, SKCanvas canvas, int pixelWidth, int pixelHeight)
         {
             if (model == null || canvas == null) return;
+            
+            // Prepare paints from theme
+            var theme = model.Theme;
 
             // Clear to transparent so the WPF Border's Background shows through
-            canvas.Clear(SKColors.Transparent);
+            canvas.Clear(new SKColor(theme.SurfaceBackgroundColor.R,
+                theme.SurfaceBackgroundColor.G,
+                theme.SurfaceBackgroundColor.B,
+                theme.SurfaceBackgroundColor.A));
 
             // Compute plot area (the inner rectangle where data is drawn)
             var plotW = (int)System.Math.Max(0, pixelWidth  - (Left + Right));
@@ -34,9 +40,21 @@ namespace FastCharts.Rendering.Skia
             // Keep scales exact for the *plot* size (not the full control size)
             model.UpdateScales(plotW, plotH);
 
-            // Prepare paints from theme
-            var theme = model.Theme;
+            
 
+            canvas.Save();
+            canvas.Translate(Left, Top);
+            using (var bg = new SKPaint
+                   {
+                       Style = SKPaintStyle.Fill,
+                       Color = new SKColor(theme.PlotBackgroundColor.R, theme.PlotBackgroundColor.G,
+                           theme.PlotBackgroundColor.B, theme.PlotBackgroundColor.A)
+                   })
+            {
+                canvas.DrawRect(0, 0, plotW, plotH, bg);
+            }
+            canvas.Restore();
+            
             using var axisPaint = new SKPaint
             {
                 IsAntialias = true,


### PR DESCRIPTION
### Summary
Light should look good on white by default. This adds PlotBackgroundColor to ITheme and fills the plot area in the Skia renderer using the theme, so Light/Dark render correctly even if the WPF control Background isn’t set.

### Changes

- Core: ITheme.PlotBackgroundColor + implementations in LightTheme and DarkTheme.

- Rendering.Skia: fill plot rect with the theme background before grid/axes/series.

### Testing

- Build/tests green.

- Demo with LightTheme now shows a white plot area automatically.

### Compatibility

- Non-breaking: new interface member with built-in implementations provided.