### PR TITLE
Series: add BandSeries (interval between two curves)

### DIFF
--- a/src/FastCharts.Core/Series/BandPoint.cs
+++ b/src/FastCharts.Core/Series/BandPoint.cs
@@ -1,0 +1,21 @@
+﻿namespace FastCharts.Core.Series
+{
+    /// <summary>
+    /// Single band datum: an interval [YLow, YHigh] at X.
+    /// </summary>
+    public struct BandPoint
+    {
+        public double X { get; set; }
+
+        public double YLow { get; set; }
+
+        public double YHigh { get; set; }
+
+        public BandPoint(double x, double yLow, double yHigh)
+        {
+            X = x;
+            YLow = yLow;
+            YHigh = yHigh;
+        }
+    }
+}

--- a/src/FastCharts.Core/Series/BandSeries.cs
+++ b/src/FastCharts.Core/Series/BandSeries.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+
+namespace FastCharts.Core.Series
+{
+    /// <summary>
+    /// Band series: fills the area between two Y values (YLow/YHigh) along X.
+    /// Typical use: confidence intervals, envelopes, Bollinger bands, etc.
+    /// </summary>
+    public sealed class BandSeries
+    {
+        /// <summary>
+        /// Points with (X, YLow, YHigh). X should be non-decreasing for a proper path.
+        /// </summary>
+        public IList<BandPoint> Data { get; }
+
+        /// <summary>
+        /// Outline stroke thickness (px). If 0, no outline is drawn.
+        /// </summary>
+        public double StrokeThickness { get; set; }
+
+        /// <summary>
+        /// Fill opacity [0..1] for the band region.
+        /// </summary>
+        public double FillOpacity { get; set; }
+
+        public bool IsEmpty
+        {
+            get
+            {
+                return Data == null || Data.Count == 0;
+            }
+        }
+
+        public BandSeries()
+        {
+            Data = new List<BandPoint>();
+            StrokeThickness = 1.5;
+            FillOpacity = 0.25;
+        }
+
+        public BandSeries(IEnumerable<BandPoint> points)
+        {
+            Data = new List<BandPoint>(points);
+            StrokeThickness = 1.5;
+            FillOpacity = 0.25;
+        }
+    }
+}

--- a/src/FastCharts.Rendering.Skia/SkiaChartRenderer.cs
+++ b/src/FastCharts.Rendering.Skia/SkiaChartRenderer.cs
@@ -217,6 +217,94 @@ namespace FastCharts.Rendering.Skia
                     seriesIndex++;
                 }
 
+                // --- BAND (fill between YLow/YHigh + optional outlines) ---
+                seriesIndex = 0;
+                foreach (var bs in model.Series.OfType<FastCharts.Core.Series.BandSeries>())
+                {
+                    if (bs.IsEmpty)
+                    {
+                        seriesIndex++;
+                        continue;
+                    }
+
+                    var c = (palette != null && seriesIndex < palette.Count)
+                        ? palette[seriesIndex]
+                        : model.Theme.PrimarySeriesColor;
+
+                    byte alpha = (byte)(System.Math.Max(0.0, System.Math.Min(1.0, bs.FillOpacity)) * c.A);
+                    var fillColor = new SKColor(c.R, c.G, c.B, alpha);
+
+                    using (var fillPaint = new SKPaint
+                           {
+                               IsAntialias = true,
+                               Style = SKPaintStyle.Fill,
+                               Color = fillColor
+                           })
+                    using (var strokePaint = new SKPaint
+                           {
+                               IsAntialias = true,
+                               Style = SKPaintStyle.Stroke,
+                               StrokeWidth = (float)bs.StrokeThickness,
+                               Color = new SKColor(c.R, c.G, c.B, c.A)
+                           })
+                    using (var bandPath = new SKPath())
+                    using (var upperPath = new SKPath())
+                    using (var lowerPath = new SKPath())
+                    {
+                        bool started = false;
+
+                        // Upper edge (YHigh) left→right
+                        for (int i = 0; i < bs.Data.Count; i++)
+                        {
+                            var p = bs.Data[i];
+
+                            float px = PixelMapper.X(p.X, model.XAxis, plotRect);
+                            float pyHigh = PixelMapper.Y(p.YHigh, model.YAxis, plotRect);
+                            float pyLow = PixelMapper.Y(p.YLow, model.YAxis, plotRect);
+
+                            if (!started)
+                            {
+                                bandPath.MoveTo(px, pyHigh);
+                                upperPath.MoveTo(px, pyHigh);
+                                lowerPath.MoveTo(px, pyLow);
+                                started = true;
+                            }
+                            else
+                            {
+                                bandPath.LineTo(px, pyHigh);
+                                upperPath.LineTo(px, pyHigh);
+                                lowerPath.LineTo(px, pyLow);
+                            }
+                        }
+
+                        // Lower edge (YLow) right→left to close polygon
+                        for (int i = bs.Data.Count - 1; i >= 0; i--)
+                        {
+                            var p = bs.Data[i];
+
+                            float px = PixelMapper.X(p.X, model.XAxis, plotRect);
+                            float pyLow = PixelMapper.Y(p.YLow, model.YAxis, plotRect);
+
+                            bandPath.LineTo(px, pyLow);
+                        }
+
+                        if (started)
+                        {
+                            bandPath.Close();
+                            canvas.DrawPath(bandPath, fillPaint);
+
+                            if (bs.StrokeThickness > 0.0)
+                            {
+                                canvas.DrawPath(upperPath, strokePaint);
+                                canvas.DrawPath(lowerPath, strokePaint);
+                            }
+                        }
+                    }
+
+                    seriesIndex++;
+                }
+
+
                 // --- 2) SCATTER (markers only, no line) ---
                 seriesIndex = 0;
                 foreach (var ss in model.Series.OfType<ScatterSeries>())
@@ -440,7 +528,7 @@ namespace FastCharts.Rendering.Skia
                                 {
                                     canvas.DrawText(lines[i], tx, ty, tipTx);
                                     ty += lineH;
-                                }                                
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Title
Series: add BandSeries (interval between two curves)

## Summary
This PR adds `BandSeries` to visualize an interval between two Y values along X (e.g., confidence bands, envelopes, Bollinger bands). The Skia renderer fills the band polygon and optionally draws the upper/lower outlines using the series palette color.

## Changes
- **Core / Series**
  - Add `BandPoint` (struct) in its own file.
  - Add `BandSeries` with `IList<BandPoint> Data`, `FillOpacity`, `StrokeThickness`.
- **Rendering / Skia**
  - Build a closed path (upper forward, lower backward) and fill it.
  - Draw upper/lower outlines if `StrokeThickness > 0`.
  - Keep drawing order: Area → Band → Scatter → Lines.

## Testing
- Manual demo: create an upper/lower sine envelope and verify the filled interval and outlines.
- (Optional) Add a smoke test later asserting non-background pixels inside the expected band region.

## Compatibility / Checklist
- [x] No breaking changes to public APIs.
- [x] .NET Framework 4.8 / C# 7.3 compatible.
- [x] One class per file, SOLID respected.
