### PR TITLE
Axes base + DateTimeAxis, plugable Pan/Zoom behaviors, Band-aware nearest, StepLine, demo updates

### DIFF
--- a/src/FastCharts.Core/Abstractions/IChartModel.cs
+++ b/src/FastCharts.Core/Abstractions/IChartModel.cs
@@ -6,6 +6,6 @@ namespace FastCharts.Core.Abstractions;
 
 public interface IChartModel
 {
-    IReadOnlyList<NumericAxis> Axes { get; }
+    IReadOnlyList<AxisBase> Axes { get; }
     IReadOnlyList<SeriesBase> Series { get; }
 }

--- a/src/FastCharts.Core/Axes/AxisBase.cs
+++ b/src/FastCharts.Core/Axes/AxisBase.cs
@@ -1,0 +1,30 @@
+using FastCharts.Core.Abstractions;
+using FastCharts.Core.Primitives;
+
+namespace FastCharts.Core.Axes;
+
+/// <summary>
+/// Common ancestor for all axes (numeric, date, category...). Exposes a double-based visible/data range for layout.
+/// Concrete axes provide typed IScale/ITicker via properties.
+/// </summary>
+public abstract class AxisBase
+{
+    /// <summary>Whole data range in data units (double). For non-double axes, use an underlying mapping (e.g., OADate).</summary>
+    public FRange DataRange { get; set; }
+
+    /// <summary>Current visible range in data units (double). For DateTime axis, use OADate conversion.</summary>
+    public FRange VisibleRange { get; set; }
+
+    /// <summary>Label format hint used by renderers when no custom formatter provided.</summary>
+    public string? LabelFormat { get; set; }
+
+    protected AxisBase()
+    {
+        DataRange = new FRange(0, 1);
+        VisibleRange = new FRange(0, 1);
+        LabelFormat = "G";
+    }
+
+    /// <summary>Update internal scale mapping using pixel min/max.</summary>
+    public abstract void UpdateScale(double pixelMin, double pixelMax);
+}

--- a/src/FastCharts.Core/Axes/DateTimeAxis.cs
+++ b/src/FastCharts.Core/Axes/DateTimeAxis.cs
@@ -1,0 +1,49 @@
+using System;
+using FastCharts.Core.Abstractions;
+using FastCharts.Core.Axes.Ticks;
+using FastCharts.Core.Primitives;
+using FastCharts.Core.Scales;
+
+namespace FastCharts.Core.Axes;
+
+/// <summary>
+/// DateTime axis with OADate (double) backing for scale/ticks interoperability.
+/// VisibleRange/DataRange are expressed in OADate doubles.
+/// </summary>
+public sealed class DateTimeAxis : AxisBase, IAxis<double>
+{
+    public DateTimeAxis()
+    {
+        Scale = new LinearScale(0, 1, 0, 1);
+        Ticker = new NiceTicker(); // later: DateTicker with smart steps
+        DataRange = new FRange(DateTime.Today.AddDays(-7).ToOADate(), DateTime.Today.ToOADate());
+        VisibleRange = DataRange;
+        LabelFormat = "yyyy-MM-dd";
+    }
+
+    public IScale<double> Scale { get; private set; }
+    public ITicker<double> Ticker { get; }
+
+    public override void UpdateScale(double pixelMin, double pixelMax)
+    {
+        Scale = new LinearScale(VisibleRange.Min, VisibleRange.Max, pixelMin, pixelMax);
+    }
+
+    public void SetVisibleRange(DateTime min, DateTime max)
+    {
+        if (min > max)
+        {
+            var t = min; min = max; max = t;
+        }
+        VisibleRange = new FRange(min.ToOADate(), max.ToOADate());
+    }
+
+    public void SetVisibleRange(double minOADate, double maxOADate)
+    {
+        if (minOADate > maxOADate)
+        {
+            var t = minOADate; minOADate = maxOADate; maxOADate = t;
+        }
+        VisibleRange = new FRange(minOADate, maxOADate);
+    }
+}

--- a/src/FastCharts.Core/Axes/NumericAxis.cs
+++ b/src/FastCharts.Core/Axes/NumericAxis.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using FastCharts.Core.Abstractions;
 using FastCharts.Core.Axes.Ticks;
@@ -8,7 +8,7 @@ using FastCharts.Core.Scales;
 
 namespace FastCharts.Core.Axes;
 
-public sealed class NumericAxis : IAxis<double>
+public sealed class NumericAxis : AxisBase, IAxis<double>
 {
     public NumericAxis()
     {
@@ -21,14 +21,9 @@ public sealed class NumericAxis : IAxis<double>
 
     public IScale<double> Scale { get; private set; }
     public ITicker<double> Ticker { get; }
-    public FRange DataRange { get; set; }
-    public FRange VisibleRange { get; set; }
-    public string? LabelFormat { get; set; } = "G";
-    
-    /// <summary>Optional number formatter for tick labels. If null, renderers fall back to LabelFormat/G.</summary>
     public INumberFormatter? NumberFormatter { get; set; }
 
-    public void UpdateScale(double pixelMin, double pixelMax)
+    public override void UpdateScale(double pixelMin, double pixelMax)
     {
         Scale = new LinearScale(VisibleRange.Min, VisibleRange.Max, pixelMin, pixelMax);
     }
@@ -39,7 +34,9 @@ public sealed class NumericAxis : IAxis<double>
     public void SetVisibleRange(double min, double max)
     {
         if (double.IsNaN(min) || double.IsNaN(max))
+        {
             return;
+        }
 
         if (min > max)
         {

--- a/src/FastCharts.Core/ChartModel.cs
+++ b/src/FastCharts.Core/ChartModel.cs
@@ -22,7 +22,7 @@ public sealed class ChartModel : IChartModel
         Viewport = new Interactivity.Viewport(new FRange(0, 1), new FRange(0, 1));
 
         Series = new ObservableCollection<SeriesBase>();
-        Axes = new ReadOnlyCollection<NumericAxis>(new[] { XAxis, YAxis });
+        Axes = new ReadOnlyCollection<AxisBase>(new AxisBase[] { XAxis, YAxis });
         Legend = new LegendModel();
     }
 
@@ -31,10 +31,10 @@ public sealed class ChartModel : IChartModel
     public NumericAxis YAxis { get; }
     public IViewport Viewport { get; }
     public ObservableCollection<SeriesBase> Series { get; }
-    public IReadOnlyList<NumericAxis> Axes { get; }
+    public IReadOnlyList<AxisBase> Axes { get; }
 
     // IChartModel (kept loose for now)
-    IReadOnlyList<NumericAxis> IChartModel.Axes => Axes;
+    IReadOnlyList<AxisBase> IChartModel.Axes => Axes;
     IReadOnlyList<SeriesBase> IChartModel.Series => Series;
     
     public Margins PlotMargins { get; set; } = new Margins(48, 16, 16, 36);

--- a/src/FastCharts.Core/Interaction/Behaviors/PanBehavior.cs
+++ b/src/FastCharts.Core/Interaction/Behaviors/PanBehavior.cs
@@ -1,0 +1,83 @@
+namespace FastCharts.Core.Interaction.Behaviors
+{
+    /// <summary>
+    /// Pans the viewport while dragging with left mouse button (unless Shift is held for ZoomRect).
+    /// Converts pixel delta to data delta using current visible ranges and plot margins.
+    /// </summary>
+    public sealed class PanBehavior : IBehavior
+    {
+        private bool _dragging;
+        private double _lastX;
+        private double _lastY;
+
+        public bool OnEvent(ChartModel model, InteractionEvent ev)
+        {
+            if (model == null)
+            {
+                return false;
+            }
+
+            model.InteractionState ??= new InteractionState();
+            var st = model.InteractionState;
+
+            switch (ev.Type)
+            {
+                case PointerEventType.Down:
+                    if (ev.Button == PointerButton.Left && !ev.Modifiers.Shift)
+                    {
+                        _dragging = true;
+                        _lastX = ev.PixelX;
+                        _lastY = ev.PixelY;
+                        st.IsPanning = true;
+                        return true;
+                    }
+                    return false;
+
+                case PointerEventType.Move:
+                    if (_dragging)
+                    {
+                        double dxPx = ev.PixelX - _lastX;
+                        double dyPx = ev.PixelY - _lastY;
+
+                        var m = model.PlotMargins;
+                        double left = m.Left, top = m.Top, right = m.Right, bottom = m.Bottom;
+                        double plotW = ev.SurfaceWidth - (left + right);
+                        double plotH = ev.SurfaceHeight - (top + bottom);
+                        if (plotW < 0) { plotW = 0; }
+                        if (plotH < 0) { plotH = 0; }
+
+                        var vx = model.XAxis.VisibleRange;
+                        var vy = model.YAxis.VisibleRange;
+                        double spanX = vx.Max - vx.Min;
+                        double spanY = vy.Max - vy.Min;
+
+                        double dxData = (plotW > 0) ? -dxPx / plotW * spanX : 0.0;
+                        double dyData = (plotH > 0) ?  dyPx / plotH * spanY : 0.0;
+
+                        if (dxData != 0.0 || dyData != 0.0)
+                        {
+                            model.Viewport.Pan(dxData, dyData);
+                        }
+
+                        _lastX = ev.PixelX;
+                        _lastY = ev.PixelY;
+                        return true;
+                    }
+                    return false;
+
+                case PointerEventType.Up:
+                case PointerEventType.Leave:
+                    if (_dragging)
+                    {
+                        _dragging = false;
+                        st.IsPanning = false;
+                        return true;
+                    }
+                    return false;
+
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/src/FastCharts.Core/Interaction/Behaviors/ZoomWheelBehavior.cs
+++ b/src/FastCharts.Core/Interaction/Behaviors/ZoomWheelBehavior.cs
@@ -1,0 +1,50 @@
+using FastCharts.Core.Primitives;
+
+namespace FastCharts.Core.Interaction.Behaviors
+{
+    /// <summary>
+    /// Zooms in/out with mouse wheel around the cursor anchor inside the plot rect.
+    /// Uses Viewport.Zoom(scaleX, scaleY, pivotData).
+    /// </summary>
+    public sealed class ZoomWheelBehavior : IBehavior
+    {
+        public double Step { get; set; } = 1.1; // >1 contracts (zoom-in)
+
+        public bool OnEvent(ChartModel model, InteractionEvent ev)
+        {
+            if (model == null) return false;
+            if (ev.Type != PointerEventType.Wheel) return false;
+
+            bool zoomIn = ev.WheelDelta > 0;
+            double scale = zoomIn ? Step : (1.0 / Step); // >1 contract, <1 expand
+
+            // Plot margins & size
+            var m = model.PlotMargins;
+            double left = m.Left, top = m.Top, right = m.Right, bottom = m.Bottom;
+            double plotW = ev.SurfaceWidth - (left + right);
+            double plotH = ev.SurfaceHeight - (top + bottom);
+            if (plotW <= 0 || plotH <= 0) return false;
+
+            // Plot-relative pixels clamped
+            double px = ev.PixelX - left; if (px < 0) px = 0; else if (px > plotW) px = plotW;
+            double py = ev.PixelY - top;  if (py < 0) py = 0; else if (py > plotH) py = plotH;
+
+            // Visible ranges
+            var vx = model.XAxis.VisibleRange;
+            var vy = model.YAxis.VisibleRange;
+            double spanX = vx.Max - vx.Min;
+            double spanY = vy.Max - vy.Min;
+
+            // Ratios 0..1 inside plot
+            double rx = plotW > 0 ? (px / plotW) : 0.0;
+            double ry = plotH > 0 ? (py / plotH) : 0.0;
+
+            // Anchor in data space (Y inverted)
+            double anchorX = vx.Min + rx * spanX;
+            double anchorY = vy.Max - ry * spanY;
+
+            model.Viewport.Zoom(scale, scale, new PointD(anchorX, anchorY));
+            return true;
+        }
+    }
+}

--- a/src/FastCharts.Core/Interaction/InteractionState.cs
+++ b/src/FastCharts.Core/Interaction/InteractionState.cs
@@ -32,6 +32,9 @@ namespace FastCharts.Core.Interaction
 
         // Legend hit test rectangles (SURFACE pixels)
         public System.Collections.Generic.List<LegendHit> LegendHits { get; set; } = new System.Collections.Generic.List<LegendHit>();
+
+        // Pan state (for UI cursor feedback)
+        public bool IsPanning { get; set; }
     }
 
     public sealed class LegendHit


### PR DESCRIPTION
•	Introduces AxisBase and DateTimeAxis (backed by OADate), generalizes IChartModel.Axes.
•	Externalizes interactions: wheel zoom and pan as behaviors, ZoomRect on Shift.
•	Improves nearest-point to handle BandSeries (edges + in-band vertical snap).
•	Adds StepLineSeries and richer demo data.
•	Rendering fix: off-range points no longer clamp to plot edges.
•	UX: hand cursor while panning.
•	Changes
•	Core
•	AxisBase (common ancestor), NumericAxis derives from it; new DateTimeAxis.
•	IChartModel.Axes now IReadOnlyList<AxisBase>.
•	InteractionState: selection, nearest, legend hits, IsPanning.
•	Behaviors: ZoomWheelBehavior, PanBehavior, ZoomRectBehavior (Shift), NearestPointBehavior (Band support).
•	Series: StepLineSeries.
•	Rendering (Skia)
•	PixelMapper: no clamp on data->pixel; keep clamp for pixel->data.
•	LegendLayer: clickable legend (already merged), muted when hidden; populate hit areas.
•	SeriesLayer: respect IsVisible for Area/Band, render StepLine.
•	Overlay: selection rect + nearest marker.
•	WPF host
•	Routes all input to behaviors; adds wheel/pan behaviors by default.
•	Cursor = Hand while panning.
•	Demos
•	Net48/Net8 show Area/Line/StepLine/Band/Scatter with titles.
•	Testing
•	Build passes on netstandard2.0, net48, net6, net8.
•	Manual: wheel zoom centers on cursor; pan with left-drag (no Shift); Shift+drag = zoom rectangle; legend click toggles visibility; nearest marker snaps on Band edges and inside band.
•	Compatibility
•	API: IChartModel.Axes type changed to AxisBase; NumericAxis still exposed as XAxis/YAxis (no breaking for typical usage).
•	Behaviors optional; defaults applied in WPF.
•	Checklist
•	[x] Builds on all targets
•	[x] Defaults preserved (crosshair, zoom/pan, legend)
•	[x] No dynamic, one type per file
•	[x] Tests compile; visual demos OK
