### PR TITLE
add DateTimeAxis + axis replace API; format Date ticks; add Pan/ZoomWheel behaviors; demos updated; add DateTicker tests

### DIFF
--- a/demos/DemoApp.Net48/ViewModels/MainViewModel.cs
+++ b/demos/DemoApp.Net48/ViewModels/MainViewModel.cs
@@ -5,6 +5,7 @@ using FastCharts.Core;
 using FastCharts.Core.Primitives;
 using FastCharts.Core.Series;
 using FastCharts.Core.Themes.BuiltIn;
+using FastCharts.Core.Axes;
 
 namespace DemoApp.Net48.ViewModels
 {
@@ -18,27 +19,33 @@ namespace DemoApp.Net48.ViewModels
             Chart = new ChartModel();
 
             int n = 201;
-            var xs = Enumerable.Range(0, n).Select(i => i * 0.1).ToArray();
+            var start = DateTime.Today.AddDays(-14);
+            var xs = Enumerable.Range(0, n).Select(i => start.AddHours(i * 1.5)).ToArray();
             Chart.Theme = new DarkTheme();
 
-            var areaPts = xs.Select(x => new PointD(x, Math.Max(0, Math.Sin(x)))).ToArray();
-            Chart.AddSeries(new AreaSeries(areaPts) { Title = "Area: max(0, sin x)", Baseline = 0.0, FillOpacity = 0.35 });
+            // Switch X axis to DateTime
+            var dtAxis = new DateTimeAxis();
+            dtAxis.SetVisibleRange(start, DateTime.Today.AddDays(1));
+            Chart.ReplaceXAxis(dtAxis);
 
-            var linePts = xs.Select(x => new PointD(x, Math.Cos(x))).ToArray();
-            Chart.AddSeries(new LineSeries(linePts) { Title = "Line: cos x", StrokeThickness = 1.8 });
+            var areaPts = xs.Select(x => new PointD(x.ToOADate(), Math.Max(0, Math.Sin(x.Ticks / 1e10)))).ToArray();
+            Chart.AddSeries(new AreaSeries(areaPts) { Title = "Area: daily pattern", Baseline = 0.0, FillOpacity = 0.35 });
 
-            var stepPts = xs.Select(x => new PointD(x, Math.Sign(Math.Sin(x)))).ToArray();
-            Chart.AddSeries(new StepLineSeries(stepPts) { Title = "Step: sign(sin x)", StrokeThickness = 1.5, Mode = StepMode.Before });
+            var linePts = xs.Select(x => new PointD(x.ToOADate(), Math.Cos(x.Ticks / 1e10))).ToArray();
+            Chart.AddSeries(new LineSeries(linePts) { Title = "Line: trend", StrokeThickness = 1.8 });
+
+            var stepPts = xs.Select(x => new PointD(x.ToOADate(), Math.Sign(Math.Sin(x.Ticks / 1e10)))).ToArray();
+            Chart.AddSeries(new StepLineSeries(stepPts) { Title = "Step: regime", StrokeThickness = 1.5, Mode = StepMode.Before });
 
             var bandPts = xs.Select(x =>
             {
-                var y = Math.Sin(x);
-                return new BandPoint(x, y - 0.3, y + 0.3);
+                var t = Math.Sin(x.Ticks / 1e10);
+                return new BandPoint(x.ToOADate(), t - 0.3, t + 0.3);
             }).ToArray();
-            Chart.AddSeries(new BandSeries(bandPts) { Title = "Band: sin x ± 0.3", FillOpacity = 0.2, StrokeThickness = 1.0 });
+            Chart.AddSeries(new BandSeries(bandPts) { Title = "Band: conf", FillOpacity = 0.2, StrokeThickness = 1.0 });
 
-            var scatterPts = xs.Where((x, i) => i % 8 == 0)
-                .Select(x => new PointD(x, Math.Sin(x) + (Math.Sin(3 * x) * 0.05)))
+            var scatterPts = xs.Where((x, i) => i % 16 == 0)
+                .Select(x => new PointD(x.ToOADate(), Math.Sin(x.Ticks / 1e10) + (Math.Sin(3 * (x.Ticks / 1e10)) * 0.05)))
                 .ToArray();
             Chart.AddSeries(new ScatterSeries(scatterPts) { Title = "Scatter: samples", MarkerSize = 4.0, MarkerShape = MarkerShape.Circle });
 

--- a/demos/DemoApp.Net8/ViewModels/MainViewModel.cs
+++ b/demos/DemoApp.Net8/ViewModels/MainViewModel.cs
@@ -5,6 +5,7 @@ using FastCharts.Core;
 using FastCharts.Core.Primitives;
 using FastCharts.Core.Series;
 using FastCharts.Core.Themes.BuiltIn;
+using FastCharts.Core.Axes;
 
 namespace DemoApp.Net8.ViewModels;
 
@@ -17,41 +18,42 @@ public sealed class MainViewModel
         Chart = new ChartModel();
         Chart.Theme = new LightTheme();
 
-        int n = 201;
-        var xs = Enumerable.Range(0, n).Select(i => i * 0.1).ToArray();
+        // Switch X axis to DateTime
+        var dtAxis = new DateTimeAxis();
+        var start = DateTime.Today.AddDays(-14);
+        dtAxis.SetVisibleRange(start, DateTime.Today.AddDays(1));
+        Chart.ReplaceXAxis(dtAxis);
 
-        // 1) Area (positive part of sin)
-        var areaPts = xs.Select(x => new PointD(x, Math.Max(0, Math.Sin(x)))).ToArray();
-        var area = new AreaSeries(areaPts) { Title = "Area: max(0, sin x)", Baseline = 0.0, FillOpacity = 0.35 };
+        int n = 201;
+        var xs = Enumerable.Range(0, n).Select(i => start.AddHours(i * 1.5)).ToArray();
+
+        // Build series with OADate X values
+        var areaPts = xs.Select(x => new PointD(x.ToOADate(), Math.Max(0, Math.Sin(x.Ticks / 1e10)))).ToArray();
+        var area = new AreaSeries(areaPts) { Title = "Area: daily pattern", Baseline = 0.0, FillOpacity = 0.35 };
         Chart.AddSeries(area);
 
-        // 2) Line (cos)
-        var linePts = xs.Select(x => new PointD(x, Math.Cos(x))).ToArray();
-        var line = new LineSeries(linePts) { Title = "Line: cos x", StrokeThickness = 1.8 };
+        var linePts = xs.Select(x => new PointD(x.ToOADate(), Math.Cos(x.Ticks / 1e10))).ToArray();
+        var line = new LineSeries(linePts) { Title = "Line: trend", StrokeThickness = 1.8 };
         Chart.AddSeries(line);
 
-        // 3) Step line (square wave from sin sign)
-        var stepPts = xs.Select(x => new PointD(x, Math.Sign(Math.Sin(x)))).ToArray();
-        var step = new StepLineSeries(stepPts) { Title = "Step: sign(sin x)", StrokeThickness = 1.5, Mode = StepMode.Before };
+        var stepPts = xs.Select(x => new PointD(x.ToOADate(), Math.Sign(Math.Sin(x.Ticks / 1e10)))).ToArray();
+        var step = new StepLineSeries(stepPts) { Title = "Step: regime", StrokeThickness = 1.5, Mode = StepMode.Before };
         Chart.AddSeries(step);
 
-        // 4) Band (sin ± 0.3)
         var bandPts = xs.Select(x =>
         {
-            var y = Math.Sin(x);
-            return new BandPoint(x, y - 0.3, y + 0.3);
+            var t = Math.Sin(x.Ticks / 1e10);
+            return new BandPoint(x.ToOADate(), t - 0.3, t + 0.3);
         }).ToArray();
-        var band = new BandSeries(bandPts) { Title = "Band: sin x ± 0.3", FillOpacity = 0.2, StrokeThickness = 1.0 };
+        var band = new BandSeries(bandPts) { Title = "Band: conf", FillOpacity = 0.2, StrokeThickness = 1.0 };
         Chart.AddSeries(band);
 
-        // 5) Scatter (decimated noisy sin)
-        var scatterPts = xs.Where((x, i) => i % 8 == 0)
-            .Select(x => new PointD(x, Math.Sin(x) + (Math.Sin(3 * x) * 0.05)))
+        var scatterPts = xs.Where((x, i) => i % 16 == 0)
+            .Select(x => new PointD(x.ToOADate(), Math.Sin(x.Ticks / 1e10) + (Math.Sin(3 * (x.Ticks / 1e10)) * 0.05)))
             .ToArray();
         var scatter = new ScatterSeries(scatterPts) { Title = "Scatter: samples", MarkerSize = 4.0, MarkerShape = MarkerShape.Circle };
         Chart.AddSeries(scatter);
 
-        // Nominal size; renderer will update on arrange
         Chart.UpdateScales(800, 400);
     }
 }

--- a/src/FastCharts.Core/Axes/AxisExtensions.cs
+++ b/src/FastCharts.Core/Axes/AxisExtensions.cs
@@ -1,0 +1,39 @@
+using System;
+using FastCharts.Core.Abstractions;
+using FastCharts.Core.Primitives;
+
+namespace FastCharts.Core.Axes
+{
+    /// <summary>
+    /// Extensions for IAxis<double> to set visible range with guards.
+    /// </summary>
+    public static class AxisExtensions
+    {
+        public static void SetVisibleRange(this IAxis<double> axis, double min, double max)
+        {
+            if (axis == null)
+            {
+                return;
+            }
+
+            if (double.IsNaN(min) || double.IsNaN(max))
+            {
+                return;
+            }
+
+            if (min > max)
+            {
+                var t = min; min = max; max = t;
+            }
+
+            if (Math.Abs(min - max) < double.Epsilon)
+            {
+                var eps = (min == 0d) ? 1e-6 : Math.Abs(min) * 1e-6;
+                min -= eps;
+                max += eps;
+            }
+
+            axis.VisibleRange = new FRange(min, max);
+        }
+    }
+}

--- a/src/FastCharts.Core/Axes/DateTimeAxis.cs
+++ b/src/FastCharts.Core/Axes/DateTimeAxis.cs
@@ -3,6 +3,7 @@ using FastCharts.Core.Abstractions;
 using FastCharts.Core.Axes.Ticks;
 using FastCharts.Core.Primitives;
 using FastCharts.Core.Scales;
+using FastCharts.Core.Formatting;
 
 namespace FastCharts.Core.Axes;
 
@@ -15,14 +16,17 @@ public sealed class DateTimeAxis : AxisBase, IAxis<double>
     public DateTimeAxis()
     {
         Scale = new LinearScale(0, 1, 0, 1);
-        Ticker = new NiceTicker(); // later: DateTicker with smart steps
+        Ticker = new DateTicker();
         DataRange = new FRange(DateTime.Today.AddDays(-7).ToOADate(), DateTime.Today.ToOADate());
         VisibleRange = DataRange;
         LabelFormat = "yyyy-MM-dd";
+        DateTimeFormatter = new AdaptiveDateTimeFormatter();
     }
 
     public IScale<double> Scale { get; private set; }
     public ITicker<double> Ticker { get; }
+
+    public IDateTimeFormatter? DateTimeFormatter { get; set; }
 
     public override void UpdateScale(double pixelMin, double pixelMax)
     {

--- a/src/FastCharts.Core/Axes/Ticks/DateTicker.cs
+++ b/src/FastCharts.Core/Axes/Ticks/DateTicker.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using FastCharts.Core.Abstractions;
+using FastCharts.Core.Primitives;
+
+namespace FastCharts.Core.Axes.Ticks
+{
+    /// <summary>
+    /// Date/Time ticker based on OADate doubles. Chooses sensible steps from seconds to years
+    /// depending on the visible span and returns ticks as OADate values.
+    /// </summary>
+    public sealed class DateTicker : ITicker<double>
+    {
+        public IReadOnlyList<double> GetTicks(FRange visibleRange, double approxStep)
+        {
+            var ticks = new List<double>();
+            double span = visibleRange.Max - visibleRange.Min;
+            if (span <= 0 || double.IsNaN(span) || double.IsInfinity(span))
+            {
+                return ticks;
+            }
+
+            var min = ClampOADate(visibleRange.Min);
+            var max = ClampOADate(visibleRange.Max);
+            DateTime dtMin = DateTime.FromOADate(min);
+            DateTime dtMax = DateTime.FromOADate(max);
+
+            // Choose granularity based on total days
+            double days = span; // 1.0 OADate = 1 day
+
+            TimeUnit unit;
+            int stepCount;
+            ChooseUnit(days, out unit, out stepCount);
+
+            // Align start to unit boundary
+            DateTime start = Align(dtMin, unit, stepCount);
+
+            // Iterate
+            for (DateTime d = start; d <= dtMax.AddSeconds(1); d = Add(d, unit, stepCount))
+            {
+                double oa = d.ToOADate();
+                if (oa >= min - 1e-7 && oa <= max + 1e-7)
+                {
+                    ticks.Add(oa);
+                }
+                if (ticks.Count > 5000) break; // safety
+            }
+
+            return ticks;
+        }
+
+        private enum TimeUnit { Second, Minute, Hour, Day, Month, Year }
+
+        private static void ChooseUnit(double days, out TimeUnit unit, out int step)
+        {
+            if (days <= 1.0 / 24.0) { unit = TimeUnit.Minute; step = 5; return; }         // < 1h => 5 min
+            if (days <= 2.0)        { unit = TimeUnit.Hour; step = 1; return; }           // <= 2d => hourly
+            if (days <= 10.0)       { unit = TimeUnit.Hour; step = 6; return; }           // <= 10d => 6h
+            if (days <= 40.0)       { unit = TimeUnit.Day; step = 1; return; }            // <= 40d => daily
+            if (days <= 200.0)      { unit = TimeUnit.Day; step = 7; return; }            // <= ~6m => weekly
+            if (days <= 800.0)      { unit = TimeUnit.Month; step = 1; return; }          // <= ~2y => monthly
+            if (days <= 3650.0)     { unit = TimeUnit.Month; step = 3; return; }          // <= 10y => quarterly
+            unit = TimeUnit.Year; step = 1;                                               // big spans => yearly
+        }
+
+        private static DateTime Align(DateTime t, TimeUnit unit, int step)
+        {
+            switch (unit)
+            {
+                case TimeUnit.Second:
+                    return new DateTime(t.Year, t.Month, t.Day, t.Hour, t.Minute, (t.Second / step) * step, DateTimeKind.Local);
+                case TimeUnit.Minute:
+                    return new DateTime(t.Year, t.Month, t.Day, t.Hour, (t.Minute / step) * step, 0, DateTimeKind.Local);
+                case TimeUnit.Hour:
+                    return new DateTime(t.Year, t.Month, t.Day, (t.Hour / step) * step, 0, 0, DateTimeKind.Local);
+                case TimeUnit.Day:
+                    // align to midnight and then to multiple of step from the start of month
+                    var d0 = new DateTime(t.Year, t.Month, 1, 0, 0, 0, DateTimeKind.Local);
+                    int dayIndex = Math.Max(0, t.Day - 1);
+                    int alignedDayIndex = (dayIndex / step) * step;
+                    alignedDayIndex = Math.Min(alignedDayIndex, DateTime.DaysInMonth(t.Year, t.Month) - 1);
+                    return d0.AddDays(alignedDayIndex);
+                case TimeUnit.Month:
+                    return new DateTime(t.Year, ((t.Month - 1) / step) * step + 1, 1, 0, 0, 0, DateTimeKind.Local);
+                case TimeUnit.Year:
+                    return new DateTime((t.Year / step) * step, 1, 1, 0, 0, 0, DateTimeKind.Local);
+                default:
+                    return t;
+            }
+        }
+
+        private static DateTime Add(DateTime t, TimeUnit unit, int step)
+        {
+            switch (unit)
+            {
+                case TimeUnit.Second: return t.AddSeconds(step);
+                case TimeUnit.Minute: return t.AddMinutes(step);
+                case TimeUnit.Hour:   return t.AddHours(step);
+                case TimeUnit.Day:    return t.AddDays(step);
+                case TimeUnit.Month:  return t.AddMonths(step);
+                case TimeUnit.Year:   return t.AddYears(step);
+                default: return t;
+            }
+        }
+
+        private static double ClampOADate(double oa)
+        {
+            if (oa < DateTime.MinValue.ToOADate()) return DateTime.MinValue.ToOADate();
+            if (oa > DateTime.MaxValue.ToOADate()) return DateTime.MaxValue.ToOADate();
+            return oa;
+        }
+    }
+}

--- a/src/FastCharts.Core/Formatting/AdaptiveDateTimeFormatter.cs
+++ b/src/FastCharts.Core/Formatting/AdaptiveDateTimeFormatter.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace FastCharts.Core.Formatting
+{
+    /// <summary>
+    /// Adaptive DateTime formatter that chooses a format string based on the visible span.
+    /// Caller provides the total visible span in days to help decide.
+    /// </summary>
+    public sealed class AdaptiveDateTimeFormatter : IDateTimeFormatter
+    {
+        public double VisibleSpanDaysHint { get; set; } = 1.0; // can be set by renderer before formatting ticks
+
+        public string Format(DateTime value)
+        {
+            double d = VisibleSpanDaysHint;
+            if (d <= 1.0 / 24.0) // < 1h
+            {
+                return value.ToString("HH:mm:ss");
+            }
+            if (d <= 2.0) // <= 2 days
+            {
+                return value.ToString("HH:mm\nMMM d");
+            }
+            if (d <= 40.0)
+            {
+                return value.ToString("MMM d");
+            }
+            if (d <= 800.0)
+            {
+                return value.ToString("MMM yyyy");
+            }
+            return value.ToString("yyyy");
+        }
+    }
+}

--- a/src/FastCharts.Core/Formatting/IDateTimeFormatter.cs
+++ b/src/FastCharts.Core/Formatting/IDateTimeFormatter.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace FastCharts.Core.Formatting
+{
+    /// <summary>
+    /// Formats DateTime axis tick labels from OADate values.
+    /// </summary>
+    public interface IDateTimeFormatter
+    {
+        string Format(DateTime value);
+    }
+}

--- a/src/FastCharts.Core/Interaction/Behaviors/ZoomRectBehavior.cs
+++ b/src/FastCharts.Core/Interaction/Behaviors/ZoomRectBehavior.cs
@@ -1,4 +1,5 @@
 using FastCharts.Core.Primitives;
+using FastCharts.Core.Axes;
 
 namespace FastCharts.Core.Interaction.Behaviors
 {

--- a/tests/FastCharts.Core.Tests/DateTickerTests.cs
+++ b/tests/FastCharts.Core.Tests/DateTickerTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Linq;
+using Xunit;
+using FastCharts.Core.Axes.Ticks;
+using FastCharts.Core.Primitives;
+
+namespace FastCharts.Core.Tests
+{
+    public class DateTickerTests
+    {
+        [Fact]
+        public void TwoHours_Produces_Hourly_Ticks()
+        {
+            var t0 = DateTime.Today;
+            var t1 = t0.AddHours(2);
+            var tr = new FRange(t0.ToOADate(), t1.ToOADate());
+            var ticks = new DateTicker().GetTicks(tr, approxStep: 0);
+
+            Assert.True(ticks.Count >= 2);
+            // Differences around 1 hour
+            var diffs = ticks.Zip(ticks.Skip(1), (a, b) => b - a).ToArray();
+            double oneHour = TimeSpan.FromHours(1).TotalDays; // in OADate
+            Assert.All(diffs, d => Assert.InRange(d, oneHour * 0.9, oneHour * 1.1));
+        }
+
+        [Fact]
+        public void SevenDays_Produces_6h_Ticks()
+        {
+            var t0 = DateTime.Today;
+            var t1 = t0.AddDays(7);
+            var tr = new FRange(t0.ToOADate(), t1.ToOADate());
+            var ticks = new DateTicker().GetTicks(tr, 0);
+            var diffs = ticks.Zip(ticks.Skip(1), (a, b) => b - a).ToArray();
+            double sixHours = TimeSpan.FromHours(6).TotalDays;
+            Assert.All(diffs, d => Assert.InRange(d, sixHours * 0.9, sixHours * 1.1));
+        }
+
+        [Fact]
+        public void ThirtyDays_Produces_Daily_Ticks()
+        {
+            var t0 = new DateTime(2024, 1, 1);
+            var t1 = t0.AddDays(30);
+            var tr = new FRange(t0.ToOADate(), t1.ToOADate());
+            var ticks = new DateTicker().GetTicks(tr, 0);
+            var diffs = ticks.Zip(ticks.Skip(1), (a, b) => b - a).ToArray();
+            double oneDay = 1.0;
+            Assert.All(diffs, d => Assert.InRange(d, oneDay * 0.95, oneDay * 1.05));
+        }
+
+        [Fact]
+        public void OneHundredEightyDays_Produces_Weekly_Ticks()
+        {
+            var t0 = DateTime.Today;
+            var t1 = t0.AddDays(180);
+            var tr = new FRange(t0.ToOADate(), t1.ToOADate());
+            var ticks = new DateTicker().GetTicks(tr, 0);
+            var diffs = ticks.Zip(ticks.Skip(1), (a, b) => b - a).ToArray();
+            double oneWeek = 7.0;
+            Assert.All(diffs, d => Assert.InRange(d, oneWeek * 0.95, oneWeek * 1.05));
+        }
+
+        [Fact]
+        public void ThreeYears_Produces_Quarterly_Ticks()
+        {
+            var t0 = new DateTime(2020, 1, 15);
+            var t1 = t0.AddYears(3);
+            var tr = new FRange(t0.ToOADate(), t1.ToOADate());
+            var ticks = new DateTicker().GetTicks(tr, 0);
+            // month steps of 3: ensure month increments by ~3 and day normalized near start
+            var dt = ticks.Select(DateTime.FromOADate).ToArray();
+            Assert.All(dt.Zip(dt.Skip(1), (a, b) => (a, b)), pair =>
+            {
+                int dm = (pair.b.Year - pair.a.Year) * 12 + (pair.b.Month - pair.a.Month);
+                Assert.InRange(dm, 2, 4); // allow FP/edge alignment
+            });
+        }
+
+        [Fact]
+        public void FifteenYears_Produces_Yearly_Ticks()
+        {
+            var t0 = new DateTime(2000, 5, 1);
+            var t1 = t0.AddYears(15);
+            var tr = new FRange(t0.ToOADate(), t1.ToOADate());
+            var ticks = new DateTicker().GetTicks(tr, 0);
+            var dt = ticks.Select(DateTime.FromOADate).ToArray();
+            Assert.All(dt.Zip(dt.Skip(1), (a, b) => (a, b)), pair =>
+            {
+                Assert.InRange(pair.b.Year - pair.a.Year, 1, 1);
+            });
+        }
+
+        [Fact]
+        public void Ticks_Are_Monotonic_And_In_Range()
+        {
+            var t0 = new DateTime(2022, 11, 3, 10, 23, 0);
+            var t1 = t0.AddDays(12);
+            var tr = new FRange(t0.ToOADate(), t1.ToOADate());
+            var ticks = new DateTicker().GetTicks(tr, 0);
+            Assert.True(ticks.Count > 0);
+            for (int i = 1; i < ticks.Count; i++)
+            {
+                Assert.True(ticks[i] >= ticks[i - 1]);
+            }
+            Assert.True(ticks.First() >= tr.Min - 1e-6);
+            Assert.True(ticks.Last() <= tr.Max + 1e-6);
+        }
+    }
+}

--- a/tests/FastCharts.Tests/SkiaChartRendererClipAndMappingTests.cs
+++ b/tests/FastCharts.Tests/SkiaChartRendererClipAndMappingTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Xunit;
 using SkiaSharp;
@@ -6,6 +6,7 @@ using FastCharts.Core;              // ChartModel
 using FastCharts.Core.Series;       // LineSeries
 using FastCharts.Rendering.Skia;    // SkiaChartRenderer
 using FastCharts.Core.Primitives;   // PointD (si l'espace de noms diffère, adapte l'using)
+using FastCharts.Core.Axes;         // AxisExtensions
 
 namespace FastCharts.Tests
 {


### PR DESCRIPTION
•	Adds DateTimeAxis (OADate-backed) with DateTicker and AdaptiveDateTimeFormatter.
•	Introduces ReplaceXAxis/ReplaceYAxis(IAxis<double>) and updates Axes list dynamically.
•	AxesTicksLayer formats X labels as DateTime when DateTimeAxis is used.
•	Externalizes interactions: PanBehavior (left-drag), ZoomWheelBehavior (wheel around cursor), ZoomRect on Shift.
•	Improves nearest-point behavior for BandSeries (edges + in-band snap).
•	Adds StepLineSeries and fixes data->pixel clamping (no sticking at plot edges).
•	Updates demos (.NET 4.8/.NET 8) to use DateTime X axis and varied series.
•	Adds unit tests for DateTicker across multiple time spans.
Changes
•	Core: AxisBase; DateTimeAxis; DateTicker; AdaptiveDateTimeFormatter; AxisExtensions.SetVisibleRange; ReplaceXAxis/ReplaceYAxis.
•	Rendering (Skia): AxesTicksLayer DateTime formatting; SeriesLayer visibility checks; PixelMapper unclamped data->pixel.
•	Interactions: PanBehavior, ZoomWheelBehavior, ZoomRect (Shift), NearestPointBehavior for Band.
•	Demos: DateTime X axis with Area/Line/StepLine/Band/Scatter.
•	Tests: FastCharts.Core.Tests DateTickerTests (hourly/daily/weekly/monthly/quarterly/yearly spans).
Testing
•	Build succeeds on netstandard2.0, net48, net6, net8.
•	Manual: wheel zoom, pan, Shift+drag zoom rectangle, legend toggles series, DateTime ticks adapt to span.
•	Unit: DateTickerTests validate tick spacing and range.