### PR TITLE
feat(series): grouped BarSeries with demos and tests

### DIFF
--- a/demos/DemoApp.Net48/ViewModels/MainViewModel.cs
+++ b/demos/DemoApp.Net48/ViewModels/MainViewModel.cs
@@ -49,6 +49,14 @@ namespace DemoApp.Net48.ViewModels
                 .ToArray();
             Chart.AddSeries(new ScatterSeries(scatterPts) { Title = "Scatter: samples", MarkerSize = 4.0, MarkerShape = MarkerShape.Circle });
 
+            // Grouped bars (daily buckets)
+            int buckets = 10;
+            var bucketXs = Enumerable.Range(0, buckets).Select(i => start.AddDays(1 + i)).ToArray();
+            var barsA = bucketXs.Select((x, i) => new BarPoint(x.ToOADate(), (Math.Sin(i * 0.6) + 1.2) * 0.6)).ToArray();
+            var barsB = bucketXs.Select((x, i) => new BarPoint(x.ToOADate(), (Math.Cos(i * 0.6) + 1.2) * 0.5)).ToArray();
+            Chart.AddSeries(new BarSeries(barsA) { Title = "Bars A", GroupCount = 2, GroupIndex = 0, FillOpacity = 0.7 });
+            Chart.AddSeries(new BarSeries(barsB) { Title = "Bars B", GroupCount = 2, GroupIndex = 1, FillOpacity = 0.7 });
+
             Chart.UpdateScales(800, 400); // nominal size; real renderer will update on arrange
         }
     }

--- a/demos/DemoApp.Net8/ViewModels/MainViewModel.cs
+++ b/demos/DemoApp.Net8/ViewModels/MainViewModel.cs
@@ -54,6 +54,18 @@ public sealed class MainViewModel
         var scatter = new ScatterSeries(scatterPts) { Title = "Scatter: samples", MarkerSize = 4.0, MarkerShape = MarkerShape.Circle };
         Chart.AddSeries(scatter);
 
+        // Add grouped BarSeries over daily buckets (10 buckets)
+        int buckets = 10;
+        var bucketXs = Enumerable.Range(0, buckets)
+            .Select(i => start.AddDays(1 + i))
+            .ToArray();
+        var barsA = bucketXs.Select((x, i) => new BarPoint(x.ToOADate(), (Math.Sin(i * 0.6) + 1.2) * 0.6)).ToArray();
+        var barsB = bucketXs.Select((x, i) => new BarPoint(x.ToOADate(), (Math.Cos(i * 0.6) + 1.2) * 0.5)).ToArray();
+        var barSeriesA = new BarSeries(barsA) { Title = "Bars A", GroupCount = 2, GroupIndex = 0, FillOpacity = 0.7 };
+        var barSeriesB = new BarSeries(barsB) { Title = "Bars B", GroupCount = 2, GroupIndex = 1, FillOpacity = 0.7 };
+        Chart.AddSeries(barSeriesA);
+        Chart.AddSeries(barSeriesB);
+
         Chart.UpdateScales(800, 400);
     }
 }

--- a/src/FastCharts.Core/Series/BarSeries.cs
+++ b/src/FastCharts.Core/Series/BarSeries.cs
@@ -26,6 +26,13 @@ namespace FastCharts.Core.Series
         /// </summary>
         public double FillOpacity { get; set; }
 
+        /// <summary>
+        /// Grouping for side-by-side bars (clustered bars). GroupCount = total series in the cluster, GroupIndex = 0..GroupCount-1.
+        /// If null, series is treated as a single group (no clustering).
+        /// </summary>
+        public int? GroupCount { get; set; }
+        public int? GroupIndex { get; set; }
+
         public override bool IsEmpty
         {
             get { return Data == null || Data.Count == 0; }

--- a/tests/FastCharts.Core.Tests/BarSeriesTests.cs
+++ b/tests/FastCharts.Core.Tests/BarSeriesTests.cs
@@ -1,0 +1,53 @@
+using FastCharts.Core.Primitives;
+using FastCharts.Core.Series;
+using FluentAssertions;
+using Xunit;
+
+namespace FastCharts.Core.Tests;
+
+public class BarSeriesTests
+{
+    [Fact]
+    public void GetWidthFor_UsesGlobalWidth_WhenSet()
+    {
+        var s = new BarSeries(new[]
+        {
+            new BarPoint(0, 1),
+            new BarPoint(1, 2),
+            new BarPoint(2, 3),
+        }) { Width = 0.5 };
+
+        s.GetWidthFor(0).Should().Be(0.5);
+        s.GetWidthFor(1).Should().Be(0.5);
+    }
+
+    [Fact]
+    public void GetWidthFor_InfersFromSpacing_WhenNotSet()
+    {
+        var s = new BarSeries(new[]
+        {
+            new BarPoint(0, 1),
+            new BarPoint(2, 2),
+            new BarPoint(5, 3),
+        });
+        // min dx = 2 => width ~ 1.6
+        s.GetWidthFor(1).Should().BeApproximately(1.6, 1e-6);
+    }
+
+    [Fact]
+    public void GetRanges_ExpandsXByHalfBar_And_YIncludesBaseline()
+    {
+        var s = new BarSeries(new[]
+        {
+            new BarPoint(10, 2),
+            new BarPoint(20, -3)
+        }) { Baseline = 0 };
+        var xr = s.GetXRange();
+        var yr = s.GetYRange();
+
+        xr.Min.Should().BeLessThan(10);
+        xr.Max.Should().BeGreaterThan(20);
+        yr.Min.Should().BeLessThanOrEqualTo(-3);
+        yr.Max.Should().BeGreaterThanOrEqualTo(2);
+    }
+}


### PR DESCRIPTION
Summary
•	BarSeries support side-by-side grouping via GroupCount/GroupIndex.
•	Skia renderer offsets bars per group slot with inner gap.
•	Demos (Net8/Net48): add two grouped BarSeries over daily buckets.
•	Tests: BarSeriesTests for width inference/global width and X/Y ranges.
•	Build OK on netstandard2.0, net48, net6, net8.
Breaking changes
•	None.