### PR TITLE
feat(series): add OhlcSeries and ErrorBarSeries with rendering, tests and expanded demos grid

### DIFF
--- a/demos/DemoApp.Net48/MainWindow.xaml
+++ b/demos/DemoApp.Net48/MainWindow.xaml
@@ -5,8 +5,21 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:controls="clr-namespace:FastCharts.Wpf.Controls;assembly=FastCharts.Wpf"
         mc:Ignorable="d"
-        Title="MainWindow" Height="450" Width="800">
-    <controls:FastChart
-        Margin="16"
-        Model="{Binding Chart}" />
+        Title="FastCharts Demo (.NET 4.8)" Height="1200" Width="1800">
+    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+        <UniformGrid Rows="3" Columns="4" Margin="16" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+            <controls:FastChart Margin="8" Model="{Binding Charts[0]}" />
+            <controls:FastChart Margin="8" Model="{Binding Charts[1]}" />
+            <controls:FastChart Margin="8" Model="{Binding Charts[2]}" />
+            <controls:FastChart Margin="8" Model="{Binding Charts[3]}" />
+            <controls:FastChart Margin="8" Model="{Binding Charts[4]}" />
+            <controls:FastChart Margin="8" Model="{Binding Charts[5]}" />
+            <controls:FastChart Margin="8" Model="{Binding Charts[6]}" />
+            <controls:FastChart Margin="8" Model="{Binding Charts[7]}" />
+            <controls:FastChart Margin="8" Model="{Binding Charts[8]}" />
+            <controls:FastChart Margin="8" Model="{Binding Charts[9]}" />
+            <controls:FastChart Margin="8" Model="{Binding Charts[10]}" />
+            <controls:FastChart Margin="8" Model="{Binding Charts[11]}" />
+        </UniformGrid>
+    </ScrollViewer>
 </Window>

--- a/demos/DemoApp.Net48/ViewModels/MainViewModel.cs
+++ b/demos/DemoApp.Net48/ViewModels/MainViewModel.cs
@@ -1,6 +1,6 @@
 using System;
+using System.Collections.ObjectModel;
 using System.Linq;
-
 using FastCharts.Core;
 using FastCharts.Core.Primitives;
 using FastCharts.Core.Series;
@@ -9,69 +9,241 @@ using FastCharts.Core.Axes;
 
 namespace DemoApp.Net48.ViewModels
 {
-
     public sealed class MainViewModel
     {
-        public ChartModel Chart { get; }
+        public ObservableCollection<ChartModel> Charts { get; } = new ObservableCollection<ChartModel>();
 
         public MainViewModel()
         {
-            Chart = new ChartModel();
+            Charts.Add(BuildMixedChart());
+            Charts.Add(BuildBarsChart());
+            Charts.Add(BuildStackedBarsChart());
+            Charts.Add(BuildOhlcChart());
+            Charts.Add(BuildErrorBarChart());
+            Charts.Add(BuildMinimalLineChart());
+            Charts.Add(BuildAreaOnly());
+            Charts.Add(BuildScatterOnly());
+            Charts.Add(BuildStepLine());
+            Charts.Add(BuildSingleBars());
+            Charts.Add(BuildStacked100());
+            Charts.Add(BuildOhlcWithErrorOverlay());
+        }
 
-            int n = 201;
-            var start = DateTime.Today.AddDays(-14);
-            var xs = Enumerable.Range(0, n).Select(i => start.AddHours(i * 1.5)).ToArray();
-            Chart.Theme = new DarkTheme();
-
-            // Switch X axis to DateTime
+        private ChartModel CreateBase(DateTime start, DateTime end)
+        {
+            var m = new ChartModel { Theme = new DarkTheme() };
             var dtAxis = new DateTimeAxis();
-            dtAxis.SetVisibleRange(start, DateTime.Today.AddDays(1));
-            Chart.ReplaceXAxis(dtAxis);
+            dtAxis.SetVisibleRange(start, end);
+            m.ReplaceXAxis(dtAxis);
+            return m;
+        }
 
+        private ChartModel BuildMixedChart()
+        {
+            var start = DateTime.Today.AddDays(-14);
+            var end = DateTime.Today.AddDays(1);
+            int n = 201;
+            var xs = Enumerable.Range(0, n).Select(i => start.AddHours(i * 1.5)).ToArray();
+            var m = CreateBase(start, end);
             var areaPts = xs.Select(x => new PointD(x.ToOADate(), Math.Max(0, Math.Sin(x.Ticks / 1e10)))).ToArray();
-            Chart.AddSeries(new AreaSeries(areaPts) { Title = "Area: daily pattern", Baseline = 0.0, FillOpacity = 0.35 });
-
+            m.AddSeries(new AreaSeries(areaPts) { Title = "Area", Baseline = 0.0, FillOpacity = 0.35 });
             var linePts = xs.Select(x => new PointD(x.ToOADate(), Math.Cos(x.Ticks / 1e10))).ToArray();
-            Chart.AddSeries(new LineSeries(linePts) { Title = "Line: trend", StrokeThickness = 1.8 });
-
-            var stepPts = xs.Select(x => new PointD(x.ToOADate(), Math.Sign(Math.Sin(x.Ticks / 1e10)))).ToArray();
-            Chart.AddSeries(new StepLineSeries(stepPts) { Title = "Step: regime", StrokeThickness = 1.5, Mode = StepMode.Before });
-
-            var bandPts = xs.Select(x =>
-            {
-                var t = Math.Sin(x.Ticks / 1e10);
-                return new BandPoint(x.ToOADate(), t - 0.3, t + 0.3);
-            }).ToArray();
-            Chart.AddSeries(new BandSeries(bandPts) { Title = "Band: conf", FillOpacity = 0.2, StrokeThickness = 1.0 });
-
+            m.AddSeries(new LineSeries(linePts) { Title = "Line", StrokeThickness = 1.8 });
             var scatterPts = xs.Where((x, i) => i % 16 == 0)
-                .Select(x => new PointD(x.ToOADate(), Math.Sin(x.Ticks / 1e10) + (Math.Sin(3 * (x.Ticks / 1e10)) * 0.05)))
-                .ToArray();
-            Chart.AddSeries(new ScatterSeries(scatterPts) { Title = "Scatter: samples", MarkerSize = 4.0, MarkerShape = MarkerShape.Circle });
+                .Select(x => new PointD(x.ToOADate(), Math.Sin(x.Ticks / 1e10) + (Math.Sin(3 * (x.Ticks / 1e10)) * 0.05))).ToArray();
+            m.AddSeries(new ScatterSeries(scatterPts) { Title = "Scatter", MarkerSize = 4.0 });
+            m.UpdateScales(800, 400);
+            return m;
+        }
 
-            // Grouped bars (daily buckets)
+        private ChartModel BuildBarsChart()
+        {
+            var start = DateTime.Today.AddDays(-10);
+            var end = DateTime.Today.AddDays(1);
+            var m = CreateBase(start, end);
             int buckets = 10;
-            var bucketXs = Enumerable.Range(0, buckets).Select(i => start.AddDays(1 + i)).ToArray();
+            var bucketXs = Enumerable.Range(0, buckets).Select(i => start.AddDays(i)).ToArray();
             var barsA = bucketXs.Select((x, i) => new BarPoint(x.ToOADate(), (Math.Sin(i * 0.6) + 1.2) * 0.6)).ToArray();
             var barsB = bucketXs.Select((x, i) => new BarPoint(x.ToOADate(), (Math.Cos(i * 0.6) + 1.2) * 0.5)).ToArray();
-            Chart.AddSeries(new BarSeries(barsA) { Title = "Bars A", GroupCount = 2, GroupIndex = 0, FillOpacity = 0.7 });
-            Chart.AddSeries(new BarSeries(barsB) { Title = "Bars B", GroupCount = 2, GroupIndex = 1, FillOpacity = 0.7 });
+            m.AddSeries(new BarSeries(barsA) { Title = "Bars A", GroupCount = 2, GroupIndex = 0, FillOpacity = 0.7 });
+            m.AddSeries(new BarSeries(barsB) { Title = "Bars B", GroupCount = 2, GroupIndex = 1, FillOpacity = 0.7 });
+            m.UpdateScales(800, 400);
+            return m;
+        }
 
-            // Grouped stacked bars
+        private ChartModel BuildStackedBarsChart()
+        {
+            var start = DateTime.Today.AddDays(-12);
+            var end = DateTime.Today.AddDays(1);
+            var m = CreateBase(start, end);
             int sbBuckets = 8;
-            var sbXs = Enumerable.Range(0, sbBuckets).Select(i => start.AddDays(1 + i * 1.5)).ToArray();
-            var stackA = sbXs.Select((x, i) => new StackedBarPoint(
-                x.ToOADate(),
-                new[] { (Math.Sin(i * 0.5) + 1.1) * 0.4, (Math.Cos(i * 0.6) + 1.1) * 0.3, (Math.Sin(i * 0.7) + 1.1) * 0.2 }
-            )).ToArray();
-            var stackB = sbXs.Select((x, i) => new StackedBarPoint(
-                x.ToOADate(),
-                new[] { (Math.Cos(i * 0.5) + 1.1) * 0.35, (Math.Sin(i * 0.6) + 1.1) * 0.25, (Math.Cos(i * 0.4) + 1.1) * 0.2 }
-            )).ToArray();
-            Chart.AddSeries(new StackedBarSeries(stackA) { Title = "Stack A", GroupCount = 2, GroupIndex = 0, FillOpacity = 0.8 });
-            Chart.AddSeries(new StackedBarSeries(stackB) { Title = "Stack B", GroupCount = 2, GroupIndex = 1, FillOpacity = 0.8 });
+            var sbXs = Enumerable.Range(0, sbBuckets).Select(i => start.AddDays(i * 1.5)).ToArray();
+            var stackA = sbXs.Select((x, i) => new StackedBarPoint(x.ToOADate(), new[] { (Math.Sin(i * 0.5) + 1.1) * 0.4, (Math.Cos(i * 0.6) + 1.1) * 0.3, (Math.Sin(i * 0.7) + 1.1) * 0.2 })).ToArray();
+            var stackB = sbXs.Select((x, i) => new StackedBarPoint(x.ToOADate(), new[] { (Math.Cos(i * 0.5) + 1.1) * 0.35, (Math.Sin(i * 0.6) + 1.1) * 0.25, (Math.Cos(i * 0.4) + 1.1) * 0.2 })).ToArray();
+            m.AddSeries(new StackedBarSeries(stackA) { Title = "Stack A", GroupCount = 2, GroupIndex = 0, FillOpacity = 0.8 });
+            m.AddSeries(new StackedBarSeries(stackB) { Title = "Stack B", GroupCount = 2, GroupIndex = 1, FillOpacity = 0.8 });
+            m.UpdateScales(800, 400);
+            return m;
+        }
 
-            Chart.UpdateScales(800, 400); // nominal size; real renderer will update on arrange
+        private ChartModel BuildOhlcChart()
+        {
+            var start = DateTime.Today.AddDays(-20);
+            var end = DateTime.Today.AddDays(1);
+            var m = CreateBase(start, end);
+            var rand = new Random(123);
+            int n = 60;
+            double price = 100;
+            var list = new OhlcPoint[n];
+            for (int i = 0; i < n; i++)
+            {
+                double open = price;
+                double change = (rand.NextDouble() - 0.5) * 4;
+                double close = open + change;
+                double high = System.Math.Max(open, close) + rand.NextDouble() * 2;
+                double low = System.Math.Min(open, close) - rand.NextDouble() * 2;
+                price = close;
+                list[i] = new OhlcPoint(start.AddDays(i).ToOADate(), open, high, low, close);
+            }
+            m.AddSeries(new OhlcSeries(list) { Title = "OHLC" });
+            m.UpdateScales(800, 400);
+            return m;
+        }
+
+        private ChartModel BuildErrorBarChart()
+        {
+            var start = DateTime.Today.AddDays(-10);
+            var end = DateTime.Today.AddDays(1);
+            var m = CreateBase(start, end);
+            int n = 20;
+            var xs = Enumerable.Range(0, n).Select(i => start.AddDays(i * 0.5)).ToArray();
+            var rand = new Random(456);
+            var pts = xs.Select(x =>
+            {
+                double y = 50 + Math.Sin(x.DayOfYear * 0.2) * 10 + rand.NextDouble() * 4;
+                double err = 2 + rand.NextDouble() * 2;
+                return new ErrorBarPoint(x.ToOADate(), y, err, err * (0.5 + rand.NextDouble() * 0.5));
+            }).ToArray();
+            m.AddSeries(new ErrorBarSeries(pts) { Title = "ErrorBars" });
+            m.UpdateScales(800, 400);
+            return m;
+        }
+
+        private ChartModel BuildMinimalLineChart()
+        {
+            var start = DateTime.Today.AddDays(-5);
+            var end = DateTime.Today.AddDays(1);
+            var m = CreateBase(start, end);
+            int n = 60;
+            var xs = Enumerable.Range(0, n).Select(i => start.AddHours(i * 2)).ToArray();
+            var pts = xs.Select((x, i) => new PointD(x.ToOADate(), Math.Sin(i * 0.2) * 5 + 20)).ToArray();
+            m.AddSeries(new LineSeries(pts) { Title = "Line" });
+            m.UpdateScales(800, 400);
+            return m;
+        }
+
+        private ChartModel BuildAreaOnly()
+        {
+            var start = DateTime.Today.AddDays(-7);
+            var end = DateTime.Today.AddDays(1);
+            var m = CreateBase(start, end);
+            int n = 120;
+            var xs = Enumerable.Range(0, n).Select(i => start.AddHours(i)).ToArray();
+            var pts = xs.Select((x, i) => new PointD(x.ToOADate(), Math.Sin(i * 0.1) * 10 + 30)).ToArray();
+            m.AddSeries(new AreaSeries(pts) { Title = "Area Only", Baseline = 20, FillOpacity = 0.45 });
+            m.UpdateScales(800, 400);
+            return m;
+        }
+
+        private ChartModel BuildScatterOnly()
+        {
+            var start = DateTime.Today.AddDays(-3);
+            var end = DateTime.Today.AddDays(1);
+            var m = CreateBase(start, end);
+            var rand = new Random(789);
+            int n = 80;
+            var xs = Enumerable.Range(0, n).Select(i => start.AddHours(i * 1.2)).ToArray();
+            var pts = xs.Select(x => new PointD(x.ToOADate(), 40 + Math.Sin(x.Ticks / 6e11) * 5 + rand.NextDouble() * 3)).ToArray();
+            m.AddSeries(new ScatterSeries(pts) { Title = "Scatter Only", MarkerSize = 5.5 });
+            m.UpdateScales(800, 400);
+            return m;
+        }
+
+        private ChartModel BuildStepLine()
+        {
+            var start = DateTime.Today.AddDays(-6);
+            var end = DateTime.Today.AddDays(1);
+            var m = CreateBase(start, end);
+            int n = 40;
+            var xs = Enumerable.Range(0, n).Select(i => start.AddHours(i * 4)).ToArray();
+            var pts = xs.Select((x, i) => new PointD(x.ToOADate(), (i % 2 == 0 ? 10 : 20) + (i % 5 == 0 ? 5 : 0))).ToArray();
+            m.AddSeries(new StepLineSeries(pts) { Title = "Step", Mode = StepMode.Before, StrokeThickness = 2 });
+            m.UpdateScales(800, 400);
+            return m;
+        }
+
+        private ChartModel BuildSingleBars()
+        {
+            var start = DateTime.Today.AddDays(-8);
+            var end = DateTime.Today.AddDays(1);
+            var m = CreateBase(start, end);
+            int n = 12;
+            var xs = Enumerable.Range(0, n).Select(i => start.AddDays(i)).ToArray();
+            var pts = xs.Select((x, i) => new BarPoint(x.ToOADate(), Math.Sin(i * 0.4) * 8 + 15)).ToArray();
+            m.AddSeries(new BarSeries(pts) { Title = "Bars", FillOpacity = 0.75 });
+            m.UpdateScales(800, 400);
+            return m;
+        }
+
+        private ChartModel BuildStacked100()
+        {
+            var start = DateTime.Today.AddDays(-10);
+            var end = DateTime.Today.AddDays(1);
+            var m = CreateBase(start, end);
+            int n = 10;
+            var xs = Enumerable.Range(0, n).Select(i => start.AddDays(i)).ToArray();
+            var rand = new Random(321);
+            var stackPoints = xs.Select((x, i) =>
+            {
+                double a = rand.NextDouble() * 1 + 0.2;
+                double b = rand.NextDouble() * 1 + 0.2;
+                double c = rand.NextDouble() * 1 + 0.2;
+                double sum = a + b + c;
+                return new StackedBarPoint(x.ToOADate(), new[] { a / sum, b / sum, c / sum });
+            }).ToArray();
+            m.AddSeries(new StackedBarSeries(stackPoints) { Title = "Stacked 100%", FillOpacity = 0.85 });
+            m.UpdateScales(800, 400);
+            return m;
+        }
+
+        private ChartModel BuildOhlcWithErrorOverlay()
+        {
+            var start = DateTime.Today.AddDays(-15);
+            var end = DateTime.Today.AddDays(1);
+            var m = CreateBase(start, end);
+            var rand = new Random(654);
+            int n = 40;
+            double price = 50;
+            var ohlc = new OhlcPoint[n];
+            var errs = new ErrorBarPoint[n];
+            for (int i = 0; i < n; i++)
+            {
+                double open = price;
+                double change = (rand.NextDouble() - 0.5) * 3;
+                double close = open + change;
+                double high = System.Math.Max(open, close) + rand.NextDouble() * 1.5;
+                double low = System.Math.Min(open, close) - rand.NextDouble() * 1.5;
+                price = close;
+                double xOa = start.AddDays(i).ToOADate();
+                ohlc[i] = new OhlcPoint(xOa, open, high, low, close);
+                double central = (open + close) * 0.5;
+                double err = 0.5 + rand.NextDouble();
+                errs[i] = new ErrorBarPoint(xOa, central, err, err * 0.7);
+            }
+            m.AddSeries(new OhlcSeries(ohlc) { Title = "OHLC" });
+            m.AddSeries(new ErrorBarSeries(errs) { Title = "Err" });
+            m.UpdateScales(800, 400);
+            return m;
         }
     }
 }

--- a/demos/DemoApp.Net8/MainWindow.xaml
+++ b/demos/DemoApp.Net8/MainWindow.xaml
@@ -5,8 +5,21 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:controls="clr-namespace:FastCharts.Wpf.Controls;assembly=FastCharts.Wpf"
         mc:Ignorable="d"
-        Title="MainWindow" Height="450" Width="800">
-    <controls:FastChart
-        Margin="16"
-        Model="{Binding Chart}" />
+        Title="FastCharts Demo (.NET 8)" Height="1200" Width="1800">
+    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+        <UniformGrid Rows="3" Columns="4" Margin="16" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+            <controls:FastChart Margin="8" Model="{Binding Charts[0]}" />
+            <controls:FastChart Margin="8" Model="{Binding Charts[1]}" />
+            <controls:FastChart Margin="8" Model="{Binding Charts[2]}" />
+            <controls:FastChart Margin="8" Model="{Binding Charts[3]}" />
+            <controls:FastChart Margin="8" Model="{Binding Charts[4]}" />
+            <controls:FastChart Margin="8" Model="{Binding Charts[5]}" />
+            <controls:FastChart Margin="8" Model="{Binding Charts[6]}" />
+            <controls:FastChart Margin="8" Model="{Binding Charts[7]}" />
+            <controls:FastChart Margin="8" Model="{Binding Charts[8]}" />
+            <controls:FastChart Margin="8" Model="{Binding Charts[9]}" />
+            <controls:FastChart Margin="8" Model="{Binding Charts[10]}" />
+            <controls:FastChart Margin="8" Model="{Binding Charts[11]}" />
+        </UniformGrid>
+    </ScrollViewer>
 </Window>

--- a/demos/DemoApp.Net8/ViewModels/MainViewModel.cs
+++ b/demos/DemoApp.Net8/ViewModels/MainViewModel.cs
@@ -1,6 +1,6 @@
 using System;
+using System.Collections.ObjectModel;
 using System.Linq;
-
 using FastCharts.Core;
 using FastCharts.Core.Primitives;
 using FastCharts.Core.Series;
@@ -11,77 +11,238 @@ namespace DemoApp.Net8.ViewModels;
 
 public sealed class MainViewModel
 {
-    public ChartModel Chart { get; }
+    public ObservableCollection<ChartModel> Charts { get; } = new();
 
     public MainViewModel()
     {
-        Chart = new ChartModel();
-        Chart.Theme = new LightTheme();
+        Charts.Add(BuildMixedChart());          // 0
+        Charts.Add(BuildBarsChart());           // 1
+        Charts.Add(BuildStackedBarsChart());    // 2
+        Charts.Add(BuildOhlcChart());           // 3
+        Charts.Add(BuildErrorBarChart());       // 4
+        Charts.Add(BuildMinimalLineChart());    // 5
+        Charts.Add(BuildAreaOnly());            // 6
+        Charts.Add(BuildScatterOnly());         // 7
+        Charts.Add(BuildStepLine());            // 8
+        Charts.Add(BuildSingleBars());          // 9
+        Charts.Add(BuildStacked100());          //10
+        Charts.Add(BuildOhlcWithErrorOverlay()); //11
+    }
 
-        // Switch X axis to DateTime
+    private ChartModel CreateBase(DateTime start, DateTime end)
+    {
+        var m = new ChartModel { Theme = new LightTheme() };
         var dtAxis = new DateTimeAxis();
-        var start = DateTime.Today.AddDays(-14);
-        dtAxis.SetVisibleRange(start, DateTime.Today.AddDays(1));
-        Chart.ReplaceXAxis(dtAxis);
+        dtAxis.SetVisibleRange(start, end);
+        m.ReplaceXAxis(dtAxis);
+        return m;
+    }
 
+    private ChartModel BuildMixedChart()
+    {
+        var start = DateTime.Today.AddDays(-14);
+        var end = DateTime.Today.AddDays(1);
         int n = 201;
         var xs = Enumerable.Range(0, n).Select(i => start.AddHours(i * 1.5)).ToArray();
-
-        // Build series with OADate X values
+        var m = CreateBase(start, end);
         var areaPts = xs.Select(x => new PointD(x.ToOADate(), Math.Max(0, Math.Sin(x.Ticks / 1e10)))).ToArray();
-        var area = new AreaSeries(areaPts) { Title = "Area: daily pattern", Baseline = 0.0, FillOpacity = 0.35 };
-        Chart.AddSeries(area);
-
+        m.AddSeries(new AreaSeries(areaPts) { Title = "Area", Baseline = 0.0, FillOpacity = 0.35 });
         var linePts = xs.Select(x => new PointD(x.ToOADate(), Math.Cos(x.Ticks / 1e10))).ToArray();
-        var line = new LineSeries(linePts) { Title = "Line: trend", StrokeThickness = 1.8 };
-        Chart.AddSeries(line);
-
-        var stepPts = xs.Select(x => new PointD(x.ToOADate(), Math.Sign(Math.Sin(x.Ticks / 1e10)))).ToArray();
-        var step = new StepLineSeries(stepPts) { Title = "Step: regime", StrokeThickness = 1.5, Mode = StepMode.Before };
-        Chart.AddSeries(step);
-
-        var bandPts = xs.Select(x =>
-        {
-            var t = Math.Sin(x.Ticks / 1e10);
-            return new BandPoint(x.ToOADate(), t - 0.3, t + 0.3);
-        }).ToArray();
-        var band = new BandSeries(bandPts) { Title = "Band: conf", FillOpacity = 0.2, StrokeThickness = 1.0 };
-        Chart.AddSeries(band);
-
+        m.AddSeries(new LineSeries(linePts) { Title = "Line", StrokeThickness = 1.8 });
         var scatterPts = xs.Where((x, i) => i % 16 == 0)
-            .Select(x => new PointD(x.ToOADate(), Math.Sin(x.Ticks / 1e10) + (Math.Sin(3 * (x.Ticks / 1e10)) * 0.05)))
-            .ToArray();
-        var scatter = new ScatterSeries(scatterPts) { Title = "Scatter: samples", MarkerSize = 4.0, MarkerShape = MarkerShape.Circle };
-        Chart.AddSeries(scatter);
+            .Select(x => new PointD(x.ToOADate(), Math.Sin(x.Ticks / 1e10) + (Math.Sin(3 * (x.Ticks / 1e10)) * 0.05))).ToArray();
+        m.AddSeries(new ScatterSeries(scatterPts) { Title = "Scatter", MarkerSize = 4.0 });
+        m.UpdateScales(800, 400);
+        return m;
+    }
 
-        // Grouped BarSeries over daily buckets (10 buckets)
+    private ChartModel BuildBarsChart()
+    {
+        var start = DateTime.Today.AddDays(-10);
+        var end = DateTime.Today.AddDays(1);
+        var m = CreateBase(start, end);
         int buckets = 10;
-        var bucketXs = Enumerable.Range(0, buckets)
-            .Select(i => start.AddDays(1 + i))
-            .ToArray();
+        var bucketXs = Enumerable.Range(0, buckets).Select(i => start.AddDays(i)).ToArray();
         var barsA = bucketXs.Select((x, i) => new BarPoint(x.ToOADate(), (Math.Sin(i * 0.6) + 1.2) * 0.6)).ToArray();
         var barsB = bucketXs.Select((x, i) => new BarPoint(x.ToOADate(), (Math.Cos(i * 0.6) + 1.2) * 0.5)).ToArray();
-        var barSeriesA = new BarSeries(barsA) { Title = "Bars A", GroupCount = 2, GroupIndex = 0, FillOpacity = 0.7 };
-        var barSeriesB = new BarSeries(barsB) { Title = "Bars B", GroupCount = 2, GroupIndex = 1, FillOpacity = 0.7 };
-        Chart.AddSeries(barSeriesA);
-        Chart.AddSeries(barSeriesB);
+        m.AddSeries(new BarSeries(barsA) { Title = "Bars A", GroupCount = 2, GroupIndex = 0, FillOpacity = 0.7 });
+        m.AddSeries(new BarSeries(barsB) { Title = "Bars B", GroupCount = 2, GroupIndex = 1, FillOpacity = 0.7 });
+        m.UpdateScales(800, 400);
+        return m;
+    }
 
-        // Stacked bars: two stacked series grouped side-by-side
+    private ChartModel BuildStackedBarsChart()
+    {
+        var start = DateTime.Today.AddDays(-12);
+        var end = DateTime.Today.AddDays(1);
+        var m = CreateBase(start, end);
         int sbBuckets = 8;
-        var sbXs = Enumerable.Range(0, sbBuckets).Select(i => start.AddDays(1 + i * 1.5)).ToArray();
-        var stackA = sbXs.Select((x, i) => new StackedBarPoint(
-            x.ToOADate(),
-            new[] { (Math.Sin(i * 0.5) + 1.1) * 0.4, (Math.Cos(i * 0.6) + 1.1) * 0.3, (Math.Sin(i * 0.7) + 1.1) * 0.2 }
-        )).ToArray();
-        var stackB = sbXs.Select((x, i) => new StackedBarPoint(
-            x.ToOADate(),
-            new[] { (Math.Cos(i * 0.5) + 1.1) * 0.35, (Math.Sin(i * 0.6) + 1.1) * 0.25, (Math.Cos(i * 0.4) + 1.1) * 0.2 }
-        )).ToArray();
-        var sba = new StackedBarSeries(stackA) { Title = "Stack A", GroupCount = 2, GroupIndex = 0, FillOpacity = 0.8 };
-        var sbb = new StackedBarSeries(stackB) { Title = "Stack B", GroupCount = 2, GroupIndex = 1, FillOpacity = 0.8 };
-        Chart.AddSeries(sba);
-        Chart.AddSeries(sbb);
+        var sbXs = Enumerable.Range(0, sbBuckets).Select(i => start.AddDays(i * 1.5)).ToArray();
+        var stackA = sbXs.Select((x, i) => new StackedBarPoint(x.ToOADate(), new[] { (Math.Sin(i * 0.5) + 1.1) * 0.4, (Math.Cos(i * 0.6) + 1.1) * 0.3, (Math.Sin(i * 0.7) + 1.1) * 0.2 })).ToArray();
+        var stackB = sbXs.Select((x, i) => new StackedBarPoint(x.ToOADate(), new[] { (Math.Cos(i * 0.5) + 1.1) * 0.35, (Math.Sin(i * 0.6) + 1.1) * 0.25, (Math.Cos(i * 0.4) + 1.1) * 0.2 })).ToArray();
+        m.AddSeries(new StackedBarSeries(stackA) { Title = "Stack A", GroupCount = 2, GroupIndex = 0, FillOpacity = 0.8 });
+        m.AddSeries(new StackedBarSeries(stackB) { Title = "Stack B", GroupCount = 2, GroupIndex = 1, FillOpacity = 0.8 });
+        m.UpdateScales(800, 400);
+        return m;
+    }
 
-        Chart.UpdateScales(800, 400);
+    private ChartModel BuildOhlcChart()
+    {
+        var start = DateTime.Today.AddDays(-20);
+        var end = DateTime.Today.AddDays(1);
+        var m = CreateBase(start, end);
+        var rand = new Random(123);
+        int n = 60;
+        double price = 100;
+        var list = new OhlcPoint[n];
+        for (int i = 0; i < n; i++)
+        {
+            double open = price;
+            double change = (rand.NextDouble() - 0.5) * 4;
+            double close = open + change;
+            double high = System.Math.Max(open, close) + rand.NextDouble() * 2;
+            double low = System.Math.Min(open, close) - rand.NextDouble() * 2;
+            price = close;
+            list[i] = new OhlcPoint(start.AddDays(i).ToOADate(), open, high, low, close);
+        }
+        m.AddSeries(new OhlcSeries(list) { Title = "OHLC" });
+        m.UpdateScales(800, 400);
+        return m;
+    }
+
+    private ChartModel BuildErrorBarChart()
+    {
+        var start = DateTime.Today.AddDays(-10);
+        var end = DateTime.Today.AddDays(1);
+        var m = CreateBase(start, end);
+        int n = 20;
+        var xs = Enumerable.Range(0, n).Select(i => start.AddDays(i * 0.5)).ToArray();
+        var rand = new Random(456);
+        var pts = xs.Select(x =>
+        {
+            double y = 50 + Math.Sin(x.DayOfYear * 0.2) * 10 + rand.NextDouble() * 4;
+            double err = 2 + rand.NextDouble() * 2;
+            return new ErrorBarPoint(x.ToOADate(), y, err, err * (0.5 + rand.NextDouble() * 0.5));
+        }).ToArray();
+        m.AddSeries(new ErrorBarSeries(pts) { Title = "ErrorBars" });
+        m.UpdateScales(800, 400);
+        return m;
+    }
+
+    private ChartModel BuildMinimalLineChart()
+    {
+        var start = DateTime.Today.AddDays(-5);
+        var end = DateTime.Today.AddDays(1);
+        var m = CreateBase(start, end);
+        int n = 60;
+        var xs = Enumerable.Range(0, n).Select(i => start.AddHours(i * 2)).ToArray();
+        var pts = xs.Select((x, i) => new PointD(x.ToOADate(), Math.Sin(i * 0.2) * 5 + 20)).ToArray();
+        m.AddSeries(new LineSeries(pts) { Title = "Line" });
+        m.UpdateScales(800, 400);
+        return m;
+    }
+
+    private ChartModel BuildAreaOnly()
+    {
+        var start = DateTime.Today.AddDays(-7);
+        var end = DateTime.Today.AddDays(1);
+        var m = CreateBase(start, end);
+        int n = 120;
+        var xs = Enumerable.Range(0, n).Select(i => start.AddHours(i)).ToArray();
+        var pts = xs.Select((x, i) => new PointD(x.ToOADate(), Math.Sin(i * 0.1) * 10 + 30)).ToArray();
+        m.AddSeries(new AreaSeries(pts) { Title = "Area Only", Baseline = 20, FillOpacity = 0.45 });
+        m.UpdateScales(800, 400);
+        return m;
+    }
+
+    private ChartModel BuildScatterOnly()
+    {
+        var start = DateTime.Today.AddDays(-3);
+        var end = DateTime.Today.AddDays(1);
+        var m = CreateBase(start, end);
+        var rand = new Random(789);
+        int n = 80;
+        var xs = Enumerable.Range(0, n).Select(i => start.AddHours(i * 1.2)).ToArray();
+        var pts = xs.Select(x => new PointD(x.ToOADate(), 40 + Math.Sin(x.Ticks / 6e11) * 5 + rand.NextDouble() * 3)).ToArray();
+        m.AddSeries(new ScatterSeries(pts) { Title = "Scatter Only", MarkerSize = 5.5 });
+        m.UpdateScales(800, 400);
+        return m;
+    }
+
+    private ChartModel BuildStepLine()
+    {
+        var start = DateTime.Today.AddDays(-6);
+        var end = DateTime.Today.AddDays(1);
+        var m = CreateBase(start, end);
+        int n = 40;
+        var xs = Enumerable.Range(0, n).Select(i => start.AddHours(i * 4)).ToArray();
+        var pts = xs.Select((x, i) => new PointD(x.ToOADate(), (i % 2 == 0 ? 10 : 20) + (i % 5 == 0 ? 5 : 0))).ToArray();
+        m.AddSeries(new StepLineSeries(pts) { Title = "Step", Mode = StepMode.Before, StrokeThickness = 2 });
+        m.UpdateScales(800, 400);
+        return m;
+    }
+
+    private ChartModel BuildSingleBars()
+    {
+        var start = DateTime.Today.AddDays(-8);
+        var end = DateTime.Today.AddDays(1);
+        var m = CreateBase(start, end);
+        int n = 12;
+        var xs = Enumerable.Range(0, n).Select(i => start.AddDays(i)).ToArray();
+        var pts = xs.Select((x, i) => new BarPoint(x.ToOADate(), Math.Sin(i * 0.4) * 8 + 15)).ToArray();
+        m.AddSeries(new BarSeries(pts) { Title = "Bars", FillOpacity = 0.75 });
+        m.UpdateScales(800, 400);
+        return m;
+    }
+
+    private ChartModel BuildStacked100()
+    {
+        var start = DateTime.Today.AddDays(-10);
+        var end = DateTime.Today.AddDays(1);
+        var m = CreateBase(start, end);
+        int n = 10;
+        var xs = Enumerable.Range(0, n).Select(i => start.AddDays(i)).ToArray();
+        var rand = new Random(321);
+        var stackPoints = xs.Select((x, i) =>
+        {
+            double a = rand.NextDouble() * 1 + 0.2;
+            double b = rand.NextDouble() * 1 + 0.2;
+            double c = rand.NextDouble() * 1 + 0.2;
+            double sum = a + b + c;
+            return new StackedBarPoint(x.ToOADate(), new[] { a / sum, b / sum, c / sum });
+        }).ToArray();
+        m.AddSeries(new StackedBarSeries(stackPoints) { Title = "Stacked 100%", FillOpacity = 0.85 });
+        m.UpdateScales(800, 400);
+        return m;
+    }
+
+    private ChartModel BuildOhlcWithErrorOverlay()
+    {
+        var start = DateTime.Today.AddDays(-15);
+        var end = DateTime.Today.AddDays(1);
+        var m = CreateBase(start, end);
+        var rand = new Random(654);
+        int n = 40;
+        double price = 50;
+        var ohlc = new OhlcPoint[n];
+        var errs = new ErrorBarPoint[n];
+        for (int i = 0; i < n; i++)
+        {
+            double open = price;
+            double change = (rand.NextDouble() - 0.5) * 3;
+            double close = open + change;
+            double high = System.Math.Max(open, close) + rand.NextDouble() * 1.5;
+            double low = System.Math.Min(open, close) - rand.NextDouble() * 1.5;
+            price = close;
+            double xOa = start.AddDays(i).ToOADate();
+            ohlc[i] = new OhlcPoint(xOa, open, high, low, close);
+            double central = (open + close) * 0.5;
+            double err = 0.5 + rand.NextDouble();
+            errs[i] = new ErrorBarPoint(xOa, central, err, err * 0.7);
+        }
+        m.AddSeries(new OhlcSeries(ohlc) { Title = "OHLC" });
+        m.AddSeries(new ErrorBarSeries(errs) { Title = "Err" });
+        m.UpdateScales(800, 400);
+        return m;
     }
 }

--- a/src/FastCharts.Core/ChartModel.cs
+++ b/src/FastCharts.Core/ChartModel.cs
@@ -117,25 +117,40 @@ public sealed class ChartModel : IChartModel
 
         foreach (var s in Series)
         {
-            if (s is LineSeries ls && !ls.IsEmpty)
+            switch (s)
             {
-                xs.Add(ls.GetXRange());
-                ys.Add(ls.GetYRange());
-            }
-            else if (s is ScatterSeries sc && !sc.IsEmpty)
-            {
-                xs.Add(sc.GetXRange());
-                ys.Add(sc.GetYRange());
-            }
-            else if (s is BandSeries bs && !bs.IsEmpty)
-            {
-                // Band series X range from its points, Y from min(low) to max(high)
-                var minX = bs.Data.Min(p => p.X);
-                var maxX = bs.Data.Max(p => p.X);
-                var minY = bs.Data.Min(p => p.YLow);
-                var maxY = bs.Data.Max(p => p.YHigh);
-                xs.Add(new FRange(minX, maxX));
-                ys.Add(new FRange(minY, maxY));
+                case LineSeries ls when !ls.IsEmpty:
+                    xs.Add(ls.GetXRange());
+                    ys.Add(ls.GetYRange());
+                    break;
+                case ScatterSeries sc when !sc.IsEmpty:
+                    xs.Add(sc.GetXRange());
+                    ys.Add(sc.GetYRange());
+                    break;
+                case BandSeries band when !band.IsEmpty:
+                    var minX = band.Data.Min(p => p.X);
+                    var maxX = band.Data.Max(p => p.X);
+                    var minY = band.Data.Min(p => p.YLow);
+                    var maxY = band.Data.Max(p => p.YHigh);
+                    xs.Add(new FRange(minX, maxX));
+                    ys.Add(new FRange(minY, maxY));
+                    break;
+                case BarSeries bar when !bar.IsEmpty:
+                    xs.Add(bar.GetXRange());
+                    ys.Add(bar.GetYRange());
+                    break;
+                case StackedBarSeries sbar when !sbar.IsEmpty:
+                    xs.Add(sbar.GetXRange());
+                    ys.Add(sbar.GetYRange());
+                    break;
+                case OhlcSeries ohlc when !ohlc.IsEmpty:
+                    xs.Add(ohlc.GetXRange());
+                    ys.Add(ohlc.GetYRange());
+                    break;
+                case ErrorBarSeries err when !err.IsEmpty:
+                    xs.Add(err.GetXRange());
+                    ys.Add(err.GetYRange());
+                    break;
             }
         }
 

--- a/src/FastCharts.Core/Series/ErrorBarSeries.cs
+++ b/src/FastCharts.Core/Series/ErrorBarSeries.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FastCharts.Core.Series
+{
+    /// <summary>
+    /// Error bar series around a central Y value at X, with symmetric or asymmetric errors.
+    /// </summary>
+    public sealed class ErrorBarSeries : SeriesBase
+    {
+        public IList<ErrorBarPoint> Data { get; }
+
+        /// <summary>Cap width in data units (if null, inferred from min ΔX * 0.25).</summary>
+        public double? CapWidth { get; set; }
+
+        public override bool IsEmpty => Data == null || Data.Count == 0;
+
+        public ErrorBarSeries()
+        {
+            Data = new List<ErrorBarPoint>();
+            StrokeThickness = 1.2;
+        }
+
+        public ErrorBarSeries(IEnumerable<ErrorBarPoint> points)
+        {
+            Data = new List<ErrorBarPoint>(points);
+            StrokeThickness = 1.2;
+        }
+
+        public double GetCapWidth()
+        {
+            if (CapWidth.HasValue) return CapWidth.Value;
+            if (Data.Count >= 2)
+            {
+                double minDx = double.PositiveInfinity;
+                for (int i = 1; i < Data.Count; i++)
+                {
+                    double dx = System.Math.Abs(Data[i].X - Data[i - 1].X);
+                    if (dx > 0 && dx < minDx) minDx = dx;
+                }
+                if (double.IsInfinity(minDx) || minDx <= 0) return 1.0;
+                return minDx * 0.25;
+            }
+            return 1.0;
+        }
+
+        public FastCharts.Core.Primitives.FRange GetXRange()
+        {
+            if (IsEmpty) return new FastCharts.Core.Primitives.FRange(0, 0);
+            double minX = Data.Min(p => p.X);
+            double maxX = Data.Max(p => p.X);
+            double half = GetCapWidth() * 0.5;
+            return new FastCharts.Core.Primitives.FRange(minX - half, maxX + half);
+        }
+
+        public FastCharts.Core.Primitives.FRange GetYRange()
+        {
+            if (IsEmpty) return new FastCharts.Core.Primitives.FRange(0, 0);
+            double minY = Data.Min(p => p.Y - (p.NegativeError ?? p.PositiveError));
+            double maxY = Data.Max(p => p.Y + p.PositiveError);
+            return new FastCharts.Core.Primitives.FRange(minY, maxY);
+        }
+    }
+
+    public struct ErrorBarPoint
+    {
+        public double X { get; set; }
+        public double Y { get; set; }
+        /// <summary>Positive error (always required).</summary>
+        public double PositiveError { get; set; }
+        /// <summary>Optional negative error; if null, symmetric = PositiveError.</summary>
+        public double? NegativeError { get; set; }
+
+        public ErrorBarPoint(double x, double y, double positiveError, double? negativeError = null)
+        {
+            X = x; Y = y; PositiveError = positiveError; NegativeError = negativeError;
+        }
+    }
+}

--- a/src/FastCharts.Core/Series/OhlcSeries.cs
+++ b/src/FastCharts.Core/Series/OhlcSeries.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FastCharts.Core.Series
+{
+    /// <summary>
+    /// OHLC (Open-High-Low-Close) financial bar series. Each point stores O,H,L,C at X.
+    /// </summary>
+    public sealed class OhlcSeries : SeriesBase
+    {
+        public IList<OhlcPoint> Data { get; }
+
+        /// <summary>Width (data units) of the candle body / bar (auto-inferred if null).</summary>
+        public double? Width { get; set; }
+
+        /// <summary>Stroke thickness for wicks/borders.</summary>
+        public double WickThickness { get; set; } = 1.0;
+
+        /// <summary>Fill opacity for up candles (if using filled style).</summary>
+        public double UpFillOpacity { get; set; } = 0.9;
+
+        /// <summary>Fill opacity for down candles.</summary>
+        public double DownFillOpacity { get; set; } = 0.4;
+
+        /// <summary>If true, draw filled candle bodies; otherwise draw only outlines.</summary>
+        public bool Filled { get; set; } = true;
+
+        public override bool IsEmpty => Data == null || Data.Count == 0;
+
+        public OhlcSeries()
+        {
+            Data = new List<OhlcPoint>();
+        }
+
+        public OhlcSeries(IEnumerable<OhlcPoint> points)
+        {
+            Data = new List<OhlcPoint>(points);
+        }
+
+        public double GetWidthFor(int index)
+        {
+            if (Width.HasValue) return Width.Value;
+            if (Data.Count >= 2)
+            {
+                double minDx = double.PositiveInfinity;
+                for (int i = 1; i < Data.Count; i++)
+                {
+                    double dx = System.Math.Abs(Data[i].X - Data[i - 1].X);
+                    if (dx > 0 && dx < minDx) minDx = dx;
+                }
+                if (double.IsInfinity(minDx) || minDx <= 0) return 1.0;
+                return minDx * 0.6; // candles narrower than bars
+            }
+            return 1.0;
+        }
+
+        public FastCharts.Core.Primitives.FRange GetXRange()
+        {
+            if (IsEmpty) return new FastCharts.Core.Primitives.FRange(0, 0);
+            double minX = Data.Min(p => p.X);
+            double maxX = Data.Max(p => p.X);
+            double half = GetWidthFor(0) * 0.5;
+            return new FastCharts.Core.Primitives.FRange(minX - half, maxX + half);
+        }
+
+        public FastCharts.Core.Primitives.FRange GetYRange()
+        {
+            if (IsEmpty) return new FastCharts.Core.Primitives.FRange(0, 0);
+            double minY = Data.Min(p => p.Low);
+            double maxY = Data.Max(p => p.High);
+            return new FastCharts.Core.Primitives.FRange(minY, maxY);
+        }
+    }
+
+    public struct OhlcPoint
+    {
+        public double X { get; set; }
+        public double Open { get; set; }
+        public double High { get; set; }
+        public double Low { get; set; }
+        public double Close { get; set; }
+
+        public OhlcPoint(double x, double open, double high, double low, double close)
+        {
+            X = x; Open = open; High = high; Low = low; Close = close;
+        }
+    }
+}

--- a/src/FastCharts.Rendering.Skia/Rendering/Layers/SeriesLayer.cs
+++ b/src/FastCharts.Rendering.Skia/Rendering/Layers/SeriesLayer.cs
@@ -141,7 +141,6 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
                     float xL = PixelMapper.X(p.X + groupOffset - effW * 0.5, model.XAxis, pr);
                     float xR = PixelMapper.X(p.X + groupOffset + effW * 0.5, model.XAxis, pr);
 
-                    // stack segments
                     double accPos = sbs.Baseline;
                     double accNeg = sbs.Baseline;
                     if (p.Values != null && p.Values.Length > 0)
@@ -158,13 +157,10 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
                             {
                                 yStart = accNeg; yEnd = accNeg + v; accNeg = yEnd;
                             }
-
-                            // color per segment: cycle palette
                             var col = (palette != null && palette.Count > 0) ? palette[(seg) % palette.Count] : model.Theme.PrimarySeriesColor;
                             byte alpha = (byte)(System.Math.Max(0, System.Math.Min(1, sbs.FillOpacity)) * col.A);
                             using var fillSeg = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Fill, Color = new SKColor(col.R, col.G, col.B, alpha) };
                             using var strokeSeg = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Stroke, StrokeWidth = (float)System.Math.Max(1.0, sbs.StrokeThickness), Color = new SKColor(col.R, col.G, col.B, col.A) };
-
                             float y0 = PixelMapper.Y(yStart, model.YAxis, pr);
                             float y1 = PixelMapper.Y(yEnd, model.YAxis, pr);
                             var rect = SKRect.Create(System.Math.Min(xL, xR), System.Math.Min(y0, y1), System.Math.Abs(xR - xL), System.Math.Abs(y1 - y0));
@@ -176,6 +172,79 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
                 }
                 ctx.Canvas.Restore();
                 sbarIndex++;
+            }
+
+            // OHLC / Candlestick
+            int ohlcIndex = 0;
+            foreach (var os in model.Series.OfType<OhlcSeries>())
+            {
+                if (os.IsEmpty || !os.IsVisible) { ohlcIndex++; continue; }
+                var cUp = model.Theme.PrimarySeriesColor;
+                var cDown = palette != null && palette.Count > 1 ? palette[1] : new FastCharts.Core.Primitives.ColorRgba((byte)(cUp.R * 0.7), (byte)(cUp.G * 0.3), (byte)(cUp.B * 0.3), cUp.A);
+                float wickStroke = (float)System.Math.Max(1.0, os.WickThickness);
+                ctx.Canvas.Save(); ctx.Canvas.ClipRect(pr);
+                for (int i = 0; i < os.Data.Count; i++)
+                {
+                    var p = os.Data[i];
+                    double w = os.GetWidthFor(i);
+                    double half = w * 0.5;
+                    float xC = PixelMapper.X(p.X, model.XAxis, pr);
+                    float xL = PixelMapper.X(p.X - half * 0.7, model.XAxis, pr);
+                    float xR = PixelMapper.X(p.X + half * 0.7, model.XAxis, pr);
+
+                    float yOpen = PixelMapper.Y(p.Open, model.YAxis, pr);
+                    float yHigh = PixelMapper.Y(p.High, model.YAxis, pr);
+                    float yLow  = PixelMapper.Y(p.Low, model.YAxis, pr);
+                    float yClose= PixelMapper.Y(p.Close, model.YAxis, pr);
+
+                    bool up = p.Close >= p.Open;
+                    var bodyColor = up ? cUp : cDown;
+                    byte fillAlpha = (byte)((up ? os.UpFillOpacity : os.DownFillOpacity) * bodyColor.A);
+                    using var wick = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Stroke, StrokeWidth = wickStroke, Color = new SKColor(bodyColor.R, bodyColor.G, bodyColor.B, bodyColor.A) };
+                    using var bodyFill = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Fill, Color = new SKColor(bodyColor.R, bodyColor.G, bodyColor.B, fillAlpha) };
+                    using var bodyStroke = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Stroke, StrokeWidth = 1, Color = new SKColor(bodyColor.R, bodyColor.G, bodyColor.B, bodyColor.A) };
+
+                    // wick
+                    ctx.Canvas.DrawLine(xC, yHigh, xC, yLow, wick);
+
+                    // body
+                    float top = System.Math.Min(yOpen, yClose);
+                    float bot = System.Math.Max(yOpen, yClose);
+                    var rect = SKRect.Create(xL, top, xR - xL, bot - top);
+                    if (os.Filled)
+                        ctx.Canvas.DrawRect(rect, bodyFill);
+                    ctx.Canvas.DrawRect(rect, bodyStroke);
+                }
+                ctx.Canvas.Restore();
+                ohlcIndex++;
+            }
+
+            // ERROR BARS
+            int errIndex = 0;
+            foreach (var es in model.Series.OfType<ErrorBarSeries>())
+            {
+                if (es.IsEmpty || !es.IsVisible) { errIndex++; continue; }
+                var c = (palette != null && errIndex < palette.Count) ? palette[errIndex] : model.Theme.PrimarySeriesColor;
+                using var pen = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Stroke, StrokeWidth = (float)System.Math.Max(1.0, es.StrokeThickness), Color = new SKColor(c.R, c.G, c.B, c.A) };
+                double cap = es.GetCapWidth() * 0.5;
+                ctx.Canvas.Save(); ctx.Canvas.ClipRect(pr);
+                foreach (var p in es.Data)
+                {
+                    double neg = p.NegativeError ?? p.PositiveError;
+                    float xC = PixelMapper.X(p.X, model.XAxis, pr);
+                    float y = PixelMapper.Y(p.Y, model.YAxis, pr);
+                    float yTop = PixelMapper.Y(p.Y + p.PositiveError, model.YAxis, pr);
+                    float yBot = PixelMapper.Y(p.Y - neg, model.YAxis, pr);
+                    float xL = PixelMapper.X(p.X - cap, model.XAxis, pr);
+                    float xR = PixelMapper.X(p.X + cap, model.XAxis, pr);
+                    // vertical line
+                    ctx.Canvas.DrawLine(xC, yTop, xC, yBot, pen);
+                    // caps
+                    ctx.Canvas.DrawLine(xL, yTop, xR, yTop, pen);
+                    ctx.Canvas.DrawLine(xL, yBot, xR, yBot, pen);
+                }
+                ctx.Canvas.Restore();
+                errIndex++;
             }
 
             // SCATTER

--- a/tests/FastCharts.Core.Tests/OhlcAndErrorBarSeriesTests.cs
+++ b/tests/FastCharts.Core.Tests/OhlcAndErrorBarSeriesTests.cs
@@ -1,0 +1,40 @@
+using FastCharts.Core.Series;
+using FluentAssertions;
+using Xunit;
+
+namespace FastCharts.Core.Tests;
+
+public class OhlcAndErrorBarSeriesTests
+{
+    [Fact]
+    public void OhlcSeries_Ranges_ShouldUseHighLowAndPadX()
+    {
+        var s = new OhlcSeries(new[]
+        {
+            new OhlcPoint(10, 5, 9, 4, 6),
+            new OhlcPoint(20, 6, 11, 5, 7)
+        });
+        var xr = s.GetXRange();
+        var yr = s.GetYRange();
+        xr.Min.Should().BeLessThan(10);
+        xr.Max.Should().BeGreaterThan(20);
+        yr.Min.Should().Be(4);
+        yr.Max.Should().Be(11);
+    }
+
+    [Fact]
+    public void ErrorBarSeries_Ranges_ShouldIncludeCapWidthAndErrors()
+    {
+        var s = new ErrorBarSeries(new[]
+        {
+            new ErrorBarPoint(0, 10, 2, 1),
+            new ErrorBarPoint(10, 20, 3, 2)
+        });
+        var xr = s.GetXRange();
+        var yr = s.GetYRange();
+        xr.Min.Should().BeLessThan(0);
+        xr.Max.Should().BeGreaterThan(10);
+        yr.Min.Should().Be(10 - 1);
+        yr.Max.Should().Be(20 + 3);
+    }
+}


### PR DESCRIPTION
•	Core:
•	Added OhlcSeries (Open/High/Low/Close) + width inference
•	Added ErrorBarSeries (symmetric/asymmetric errors, cap width inference)
•	ChartModel AutoFit updated to include BarSeries, StackedBarSeries, OhlcSeries, ErrorBarSeries
•	Rendering (Skia):
•	Extended SeriesLayer to render OHLC (candlestick style) and ErrorBars
•	Demos:
•	Expanded WPF demos (Net8 / Net48) to 12 charts in a 3x4 UniformGrid: 0 Mixed (Area/Line/Scatter) 1 Grouped Bars 2 Grouped Stacked Bars 3 OHLC 4 ErrorBars 5 Minimal Line 6 Area Only 7 Scatter Only 8 Step Line 9 Single Bars 10 Stacked 100% 11 OHLC + Error overlay
•	Tests:
•	OhlcAndErrorBarSeriesTests (range logic)
•	Existing Bar/StackedBar tests retained
•	Notes:
•	SeriesLayer now large; planned refactor into specialized layers (AreaLayer, BarLayer, OhlcLayer, ErrorBarLayer, etc.) in next step
•	No breaking changes (only additive)
•	Build: OK on netstandard2.0, net48, net6, net8
Checklist:
•	[x] New series types
•	[x] Rendering paths
•	[x] AutoFit integration
•	[x] Demo coverage
•	[x] Unit tests
•	[x] No API breaks