### PR TITLE
chore(refactor): one file per series type struct/enum + shared RenderMath helper

### DIFF
--- a/src/FastCharts.Core/Series/BarPoint.cs
+++ b/src/FastCharts.Core/Series/BarPoint.cs
@@ -1,0 +1,17 @@
+namespace FastCharts.Core.Series
+{
+    /// <summary>
+    /// Bar datum: X position, Y value, optional per-point width.
+    /// </summary>
+    public struct BarPoint
+    {
+        public double X { get; set; }
+        public double Y { get; set; }
+        public double? Width { get; set; }
+
+        public BarPoint(double x, double y, double? width = null)
+        {
+            X = x; Y = y; Width = width;
+        }
+    }
+}

--- a/src/FastCharts.Core/Series/BarSeries.cs
+++ b/src/FastCharts.Core/Series/BarSeries.cs
@@ -4,39 +4,18 @@ using System.Linq;
 namespace FastCharts.Core.Series
 {
     /// <summary>
-    /// Vertical bar (column) series. Each data point draws a rectangle from Baseline to Y at X, with a given width in data units.
-    /// If Width is not specified per point, a default width is inferred from neighbor spacing (80% of min delta X).
+    /// Vertical bar (column) series. Each data point draws a rectangle from Baseline to Y at X.
+    /// Width is inferred if not specified (80% min ΔX).
     /// </summary>
     public sealed class BarSeries : SeriesBase
     {
         public IList<BarPoint> Data { get; }
-
-        /// <summary>
-        /// Optional global width (in data units). If set, overrides per-point widths and auto inference.
-        /// </summary>
         public double? Width { get; set; }
-
-        /// <summary>
-        /// Baseline value for bars (default 0). Bars extend from Baseline to Y.
-        /// </summary>
         public double Baseline { get; set; }
-
-        /// <summary>
-        /// Fill opacity [0..1]. Renderer will combine series color with this alpha factor.
-        /// </summary>
         public double FillOpacity { get; set; }
-
-        /// <summary>
-        /// Grouping for side-by-side bars (clustered bars). GroupCount = total series in the cluster, GroupIndex = 0..GroupCount-1.
-        /// If null, series is treated as a single group (no clustering).
-        /// </summary>
         public int? GroupCount { get; set; }
         public int? GroupIndex { get; set; }
-
-        public override bool IsEmpty
-        {
-            get { return Data == null || Data.Count == 0; }
-        }
+        public override bool IsEmpty => Data == null || Data.Count == 0;
 
         public BarSeries()
         {
@@ -52,55 +31,33 @@ namespace FastCharts.Core.Series
             FillOpacity = 0.85;
         }
 
-        /// <summary>
-        /// Returns the data-space width to use for the specified bar index, computing an inferred width if necessary.
-        /// </summary>
         public double GetWidthFor(int index)
         {
-            if (Width.HasValue)
-            {
-                return Width.Value;
-            }
+            if (Width.HasValue) return Width.Value;
             if (index >= 0 && index < Data.Count)
             {
                 var w = Data[index].Width;
-                if (w.HasValue && w.Value > 0)
-                {
-                    return w.Value;
-                }
+                if (w.HasValue && w.Value > 0) return w.Value;
             }
-
-            // infer width from neighbor spacing (80% of min delta X)
             if (Data.Count >= 2)
             {
                 double minDx = double.PositiveInfinity;
                 for (int i = 1; i < Data.Count; i++)
                 {
                     double dx = System.Math.Abs(Data[i].X - Data[i - 1].X);
-                    if (dx > 0 && dx < minDx)
-                    {
-                        minDx = dx;
-                    }
+                    if (dx > 0 && dx < minDx) minDx = dx;
                 }
-                if (double.IsInfinity(minDx) || minDx <= 0)
-                {
-                    return 1.0; // fallback
-                }
+                if (double.IsInfinity(minDx) || minDx <= 0) return 1.0;
                 return minDx * 0.8;
             }
-
             return 1.0;
         }
 
         public FastCharts.Core.Primitives.FRange GetXRange()
         {
-            if (IsEmpty)
-            {
-                return new FastCharts.Core.Primitives.FRange(0, 0);
-            }
+            if (IsEmpty) return new FastCharts.Core.Primitives.FRange(0, 0);
             double minX = Data.Min(p => p.X);
             double maxX = Data.Max(p => p.X);
-            // expand range by half width at edges
             double w0 = GetWidthFor(0) * 0.5;
             double wN = GetWidthFor(Data.Count - 1) * 0.5;
             return new FastCharts.Core.Primitives.FRange(minX - w0, maxX + wN);
@@ -108,28 +65,10 @@ namespace FastCharts.Core.Series
 
         public FastCharts.Core.Primitives.FRange GetYRange()
         {
-            if (IsEmpty)
-            {
-                return new FastCharts.Core.Primitives.FRange(0, 0);
-            }
+            if (IsEmpty) return new FastCharts.Core.Primitives.FRange(0, 0);
             double minY = Data.Min(p => System.Math.Min(p.Y, Baseline));
             double maxY = Data.Max(p => System.Math.Max(p.Y, Baseline));
             return new FastCharts.Core.Primitives.FRange(minY, maxY);
-        }
-    }
-
-    /// <summary>
-    /// Bar datum: X position, Y value (height from baseline), and optional per-point width in data units.
-    /// </summary>
-    public struct BarPoint
-    {
-        public double X { get; set; }
-        public double Y { get; set; }
-        public double? Width { get; set; }
-
-        public BarPoint(double x, double y, double? width = null)
-        {
-            X = x; Y = y; Width = width;
         }
     }
 }

--- a/src/FastCharts.Core/Series/ErrorBarPoint.cs
+++ b/src/FastCharts.Core/Series/ErrorBarPoint.cs
@@ -1,0 +1,18 @@
+namespace FastCharts.Core.Series
+{
+    /// <summary>
+    /// A single error bar datum with symmetric or asymmetric errors.
+    /// </summary>
+    public struct ErrorBarPoint
+    {
+        public double X { get; set; }
+        public double Y { get; set; }
+        public double PositiveError { get; set; }
+        public double? NegativeError { get; set; }
+
+        public ErrorBarPoint(double x, double y, double positiveError, double? negativeError = null)
+        {
+            X = x; Y = y; PositiveError = positiveError; NegativeError = negativeError;
+        }
+    }
+}

--- a/src/FastCharts.Core/Series/ErrorBarSeries.cs
+++ b/src/FastCharts.Core/Series/ErrorBarSeries.cs
@@ -9,10 +9,7 @@ namespace FastCharts.Core.Series
     public sealed class ErrorBarSeries : SeriesBase
     {
         public IList<ErrorBarPoint> Data { get; }
-
-        /// <summary>Cap width in data units (if null, inferred from min ΔX * 0.25).</summary>
         public double? CapWidth { get; set; }
-
         public override bool IsEmpty => Data == null || Data.Count == 0;
 
         public ErrorBarSeries()
@@ -59,21 +56,6 @@ namespace FastCharts.Core.Series
             double minY = Data.Min(p => p.Y - (p.NegativeError ?? p.PositiveError));
             double maxY = Data.Max(p => p.Y + p.PositiveError);
             return new FastCharts.Core.Primitives.FRange(minY, maxY);
-        }
-    }
-
-    public struct ErrorBarPoint
-    {
-        public double X { get; set; }
-        public double Y { get; set; }
-        /// <summary>Positive error (always required).</summary>
-        public double PositiveError { get; set; }
-        /// <summary>Optional negative error; if null, symmetric = PositiveError.</summary>
-        public double? NegativeError { get; set; }
-
-        public ErrorBarPoint(double x, double y, double positiveError, double? negativeError = null)
-        {
-            X = x; Y = y; PositiveError = positiveError; NegativeError = negativeError;
         }
     }
 }

--- a/src/FastCharts.Core/Series/OhlcPoint.cs
+++ b/src/FastCharts.Core/Series/OhlcPoint.cs
@@ -1,0 +1,19 @@
+namespace FastCharts.Core.Series
+{
+    /// <summary>
+    /// Single OHLC data point.
+    /// </summary>
+    public struct OhlcPoint
+    {
+        public double X { get; set; }
+        public double Open { get; set; }
+        public double High { get; set; }
+        public double Low { get; set; }
+        public double Close { get; set; }
+
+        public OhlcPoint(double x, double open, double high, double low, double close)
+        {
+            X = x; Open = open; High = high; Low = low; Close = close;
+        }
+    }
+}

--- a/src/FastCharts.Core/Series/OhlcSeries.cs
+++ b/src/FastCharts.Core/Series/OhlcSeries.cs
@@ -9,22 +9,11 @@ namespace FastCharts.Core.Series
     public sealed class OhlcSeries : SeriesBase
     {
         public IList<OhlcPoint> Data { get; }
-
-        /// <summary>Width (data units) of the candle body / bar (auto-inferred if null).</summary>
         public double? Width { get; set; }
-
-        /// <summary>Stroke thickness for wicks/borders.</summary>
         public double WickThickness { get; set; } = 1.0;
-
-        /// <summary>Fill opacity for up candles (if using filled style).</summary>
         public double UpFillOpacity { get; set; } = 0.9;
-
-        /// <summary>Fill opacity for down candles.</summary>
         public double DownFillOpacity { get; set; } = 0.4;
-
-        /// <summary>If true, draw filled candle bodies; otherwise draw only outlines.</summary>
         public bool Filled { get; set; } = true;
-
         public override bool IsEmpty => Data == null || Data.Count == 0;
 
         public OhlcSeries()
@@ -49,7 +38,7 @@ namespace FastCharts.Core.Series
                     if (dx > 0 && dx < minDx) minDx = dx;
                 }
                 if (double.IsInfinity(minDx) || minDx <= 0) return 1.0;
-                return minDx * 0.6; // candles narrower than bars
+                return minDx * 0.6;
             }
             return 1.0;
         }
@@ -69,20 +58,6 @@ namespace FastCharts.Core.Series
             double minY = Data.Min(p => p.Low);
             double maxY = Data.Max(p => p.High);
             return new FastCharts.Core.Primitives.FRange(minY, maxY);
-        }
-    }
-
-    public struct OhlcPoint
-    {
-        public double X { get; set; }
-        public double Open { get; set; }
-        public double High { get; set; }
-        public double Low { get; set; }
-        public double Close { get; set; }
-
-        public OhlcPoint(double x, double open, double high, double low, double close)
-        {
-            X = x; Open = open; High = high; Low = low; Close = close;
         }
     }
 }

--- a/src/FastCharts.Core/Series/StackedBarPoint.cs
+++ b/src/FastCharts.Core/Series/StackedBarPoint.cs
@@ -1,0 +1,17 @@
+namespace FastCharts.Core.Series
+{
+    /// <summary>
+    /// Stacked bar datum containing segment array.
+    /// </summary>
+    public struct StackedBarPoint
+    {
+        public double X { get; set; }
+        public double[] Values { get; set; }
+        public double? Width { get; set; }
+
+        public StackedBarPoint(double x, double[] values, double? width = null)
+        {
+            X = x; Values = values; Width = width;
+        }
+    }
+}

--- a/src/FastCharts.Core/Series/StackedBarSeries.cs
+++ b/src/FastCharts.Core/Series/StackedBarSeries.cs
@@ -96,19 +96,4 @@ namespace FastCharts.Core.Series
             return new FastCharts.Core.Primitives.FRange(minY, maxY);
         }
     }
-
-    /// <summary>
-    /// A stacked bar point at X with multiple segment values. Optional per-point width.
-    /// </summary>
-    public struct StackedBarPoint
-    {
-        public double X { get; set; }
-        public double[] Values { get; set; }
-        public double? Width { get; set; }
-
-        public StackedBarPoint(double x, double[] values, double? width = null)
-        {
-            X = x; Values = values; Width = width;
-        }
-    }
 }

--- a/src/FastCharts.Core/Series/StepLineSeries.cs
+++ b/src/FastCharts.Core/Series/StepLineSeries.cs
@@ -3,17 +3,16 @@ using FastCharts.Core.Primitives;
 
 namespace FastCharts.Core.Series
 {
-    public enum StepMode
-    {
-        Before, // horizontal then vertical (left step)
-        After   // vertical then horizontal (right step)
-    }
-
     public sealed class StepLineSeries : LineSeries
     {
         public StepMode Mode { get; set; } = StepMode.Before;
 
-        public StepLineSeries() : base() { }
-        public StepLineSeries(IEnumerable<PointD> points) : base(points) { }
+        public StepLineSeries() : base()
+        {
+        }
+
+        public StepLineSeries(IEnumerable<PointD> points) : base(points)
+        {
+        }
     }
 }

--- a/src/FastCharts.Core/Series/StepMode.cs
+++ b/src/FastCharts.Core/Series/StepMode.cs
@@ -1,0 +1,8 @@
+namespace FastCharts.Core.Series
+{
+    public enum StepMode
+    {
+        Before,
+        After
+    }
+}

--- a/src/FastCharts.Rendering.Skia/Rendering/Layers/AreaBandLayer.cs
+++ b/src/FastCharts.Rendering.Skia/Rendering/Layers/AreaBandLayer.cs
@@ -5,7 +5,6 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
 {
     internal sealed class AreaBandLayer : ISeriesSubLayer
     {
-        private static double Clamp01(double v) => v < 0 ? 0 : (v > 1 ? 1 : v);
         public void Render(RenderContext ctx)
         {
             var model = ctx.Model;
@@ -36,7 +35,7 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
                     float baseY = PixelMapper.Y(area.Baseline, model.YAxis, pr);
                     path.LineTo(lastX, baseY);
                     path.Close();
-                    byte alpha = (byte)(Clamp01(area.FillOpacity) * c.A);
+                    byte alpha = (byte)(RenderMath.Clamp01(area.FillOpacity) * c.A);
                     using var fill = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Fill, Color = new SKColor(c.R, c.G, c.B, alpha) };
                     ctx.Canvas.Save(); ctx.Canvas.ClipRect(pr); ctx.Canvas.DrawPath(path, fill); ctx.Canvas.Restore();
                 }
@@ -49,7 +48,7 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
             {
                 if (s is not BandSeries bs || bs.IsEmpty || !bs.IsVisible) continue;
                 var c = (paletteCount > 0 && bandIndex < paletteCount) ? palette[bandIndex] : model.Theme.PrimarySeriesColor;
-                byte alpha = (byte)(Clamp01(bs.FillOpacity) * c.A);
+                byte alpha = (byte)(RenderMath.Clamp01(bs.FillOpacity) * c.A);
                 using var fillPaint = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Fill, Color = new SKColor(c.R, c.G, c.B, alpha) };
                 using var strokePaint = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Stroke, StrokeWidth = (float)bs.StrokeThickness, Color = new SKColor(c.R, c.G, c.B, c.A) };
                 using var bandPath = new SKPath();

--- a/src/FastCharts.Rendering.Skia/Rendering/Layers/BarLayer.cs
+++ b/src/FastCharts.Rendering.Skia/Rendering/Layers/BarLayer.cs
@@ -5,7 +5,6 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
 {
     internal sealed class BarLayer : ISeriesSubLayer
     {
-        private static double Clamp01(double v) => v < 0 ? 0 : (v > 1 ? 1 : v);
         public void Render(RenderContext ctx)
         {
             var model = ctx.Model; var pr = ctx.PlotRect; var palette = model.Theme.SeriesPalette; int paletteCount = palette?.Count ?? 0;
@@ -14,7 +13,7 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
             {
                 if (s is not BarSeries bs || bs.IsEmpty || !bs.IsVisible) continue;
                 var c = (paletteCount > 0 && barIndex < paletteCount) ? palette[barIndex] : model.Theme.PrimarySeriesColor;
-                byte alpha = (byte)(Clamp01(bs.FillOpacity) * c.A);
+                byte alpha = (byte)(RenderMath.Clamp01(bs.FillOpacity) * c.A);
                 using var fillPaint = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Fill, Color = new SKColor(c.R, c.G, c.B, alpha) };
                 using var strokePaint = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Stroke, StrokeWidth = (float)System.Math.Max(1.0, bs.StrokeThickness), Color = new SKColor(c.R, c.G, c.B, c.A) };
                 int groupCount = bs.GroupCount.GetValueOrDefault(1);

--- a/src/FastCharts.Rendering.Skia/Rendering/Layers/OhlcLayer.cs
+++ b/src/FastCharts.Rendering.Skia/Rendering/Layers/OhlcLayer.cs
@@ -5,7 +5,6 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
 {
     internal sealed class OhlcLayer : ISeriesSubLayer
     {
-        private static double Clamp01(double v) => v < 0 ? 0 : (v > 1 ? 1 : v);
         public void Render(RenderContext ctx)
         {
             var model = ctx.Model; var pr = ctx.PlotRect; var palette = model.Theme.SeriesPalette; int paletteCount = palette?.Count ?? 0;
@@ -29,7 +28,7 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
                     float yClose = PixelMapper.Y(p.Close, model.YAxis, pr);
                     bool up = p.Close >= p.Open;
                     var bodyColor = up ? cUp : cDown;
-                    byte fillAlpha = (byte)(Clamp01(up ? os.UpFillOpacity : os.DownFillOpacity) * bodyColor.A);
+                    byte fillAlpha = (byte)(RenderMath.Clamp01(up ? os.UpFillOpacity : os.DownFillOpacity) * bodyColor.A);
                     using var wick = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Stroke, StrokeWidth = wickStroke, Color = new SKColor(bodyColor.R, bodyColor.G, bodyColor.B, bodyColor.A) };
                     using var bodyFill = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Fill, Color = new SKColor(bodyColor.R, bodyColor.G, bodyColor.B, fillAlpha) };
                     using var bodyStroke = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Stroke, StrokeWidth = 1, Color = new SKColor(bodyColor.R, bodyColor.G, bodyColor.B, bodyColor.A) };

--- a/src/FastCharts.Rendering.Skia/Rendering/Layers/RenderMath.cs
+++ b/src/FastCharts.Rendering.Skia/Rendering/Layers/RenderMath.cs
@@ -1,0 +1,7 @@
+namespace FastCharts.Rendering.Skia.Rendering.Layers
+{
+    internal static class RenderMath
+    {
+        public static double Clamp01(double v) => v < 0 ? 0 : (v > 1 ? 1 : v);
+    }
+}

--- a/src/FastCharts.Rendering.Skia/Rendering/Layers/SeriesLayer.cs
+++ b/src/FastCharts.Rendering.Skia/Rendering/Layers/SeriesLayer.cs
@@ -1,19 +1,18 @@
-using FastCharts.Core.Series;
-
 namespace FastCharts.Rendering.Skia.Rendering.Layers
 {
     internal sealed class SeriesLayer : IRenderLayer
     {
-        private readonly ISeriesSubLayer[] _layers = new ISeriesSubLayer[]
+        // Ordered sublayers (back-to-front) to preserve expected overlap semantics
+        private readonly ISeriesSubLayer[] _layers =
         {
-            new AreaBandLayer(),
-            new BarLayer(),
-            new StackedBarLayer(),
-            new OhlcLayer(),
-            new ErrorBarLayer(),
-            new ScatterLayer(),
-            new StepLineLayer(),
-            new LineLayer()
+            new AreaBandLayer(),   // fills first
+            new BarLayer(),        // grouped bars
+            new StackedBarLayer(), // stacked bars
+            new OhlcLayer(),       // candles
+            new ErrorBarLayer(),   // error bars overlay
+            new ScatterLayer(),    // markers
+            new StepLineLayer(),   // step lines
+            new LineLayer()        // plain lines on top
         };
 
         public void Render(RenderContext ctx)

--- a/src/FastCharts.Rendering.Skia/Rendering/Layers/StackedBarLayer.cs
+++ b/src/FastCharts.Rendering.Skia/Rendering/Layers/StackedBarLayer.cs
@@ -5,7 +5,6 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
 {
     internal sealed class StackedBarLayer : ISeriesSubLayer
     {
-        private static double Clamp01(double v) => v < 0 ? 0 : (v > 1 ? 1 : v);
         public void Render(RenderContext ctx)
         {
             var model = ctx.Model; var pr = ctx.PlotRect; var palette = model.Theme.SeriesPalette; int paletteCount = palette?.Count ?? 0;
@@ -39,7 +38,7 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
                             if (v >= 0) { yStart = accPos; yEnd = accPos + v; accPos = yEnd; }
                             else { yStart = accNeg; yEnd = accNeg + v; accNeg = yEnd; }
                             var col = (paletteCount > 0) ? palette[seg % paletteCount] : model.Theme.PrimarySeriesColor;
-                            byte alpha = (byte)(Clamp01(sbs.FillOpacity) * col.A);
+                            byte alpha = (byte)(RenderMath.Clamp01(sbs.FillOpacity) * col.A);
                             using var fillSeg = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Fill, Color = new SKColor(col.R, col.G, col.B, alpha) };
                             using var strokeSeg = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Stroke, StrokeWidth = (float)System.Math.Max(1.0, sbs.StrokeThickness), Color = new SKColor(col.R, col.G, col.B, col.A) };
                             float y0 = PixelMapper.Y(yStart, model.YAxis, pr);


### PR DESCRIPTION
### Core:
•	Extracted BarPoint, StackedBarPoint, OhlcPoint, ErrorBarPoint, StepMode into dedicated files.
•	Converted expression-bodied constructors (e.g. OhlcSeries) to block style per project code style.
•	Rendering:
•	Added RenderMath.Clamp01 helper; removed duplicated local Clamp01 functions across layers.
### Consistency:
•	Ensured one type (class/struct/enum) per file policy.
•	Unified constructor formatting.
### No functional changes; purely structural/cleanup.
### All tests pass (smoke + series + autofit).
### Targets unaffected (netstandard2.0, net48, net6, net8).
