### PR TITLE
feat(tooltip): multi-series aggregated tooltip, lock/unlock (ESC) + demo chart

### DIFF
--- a/demos/DemoApp.Net48/ViewModels/MainViewModel.cs
+++ b/demos/DemoApp.Net48/ViewModels/MainViewModel.cs
@@ -27,6 +27,7 @@ namespace DemoApp.Net48.ViewModels
             Charts.Add(BuildSingleBars());
             Charts.Add(BuildStacked100());
             Charts.Add(BuildOhlcWithErrorOverlay());
+            Charts.Add(BuildMultiSeriesTooltipShowcase());
         }
 
         private ChartModel CreateBase(DateTime start, DateTime end)
@@ -242,6 +243,25 @@ namespace DemoApp.Net48.ViewModels
             }
             m.AddSeries(new OhlcSeries(ohlc) { Title = "OHLC" });
             m.AddSeries(new ErrorBarSeries(errs) { Title = "Err" });
+            m.UpdateScales(800, 400);
+            return m;
+        }
+
+        private ChartModel BuildMultiSeriesTooltipShowcase()
+        {
+            var start = DateTime.Today.AddDays(-3);
+            var end = DateTime.Today.AddDays(0.5);
+            var m = CreateBase(start, end);
+            var xs = Enumerable.Range(0, 300).Select(i => start.AddMinutes(i * 15)).ToArray();
+            var line = xs.Select((x,i) => new PointD(x.ToOADate(), 50 + Math.Sin(i * 0.15)*10 + Math.Sin(i*0.03)*5)).ToArray();
+            m.AddSeries(new LineSeries(line) { Title = "Line A", StrokeThickness = 1.4 });
+            var area = xs.Where((_,i)=> i%3==0).Select((x,i) => new PointD(x.ToOADate(), 40 + Math.Cos(i*0.18)*6)).ToArray();
+            m.AddSeries(new AreaSeries(area) { Title = "Area B", Baseline = 35, FillOpacity = 0.35 });
+            var scatter = xs.Where((_,i)=> i%20==0).Select((x,i) => new PointD(x.ToOADate(), 55 + Math.Sin(i*0.9)*4)).ToArray();
+            m.AddSeries(new ScatterSeries(scatter) { Title = "Scatter C", MarkerSize = 4 });
+            var dayXs = Enumerable.Range(0, 4).Select(i => start.AddDays(i)).ToArray();
+            var bars = dayXs.Select((x,i) => new BarPoint(x.ToOADate(), 30 + i*2 + Math.Sin(i)*3)).ToArray();
+            m.AddSeries(new BarSeries(bars) { Title = "Bars D", FillOpacity = 0.6 });
             m.UpdateScales(800, 400);
             return m;
         }

--- a/demos/DemoApp.Net8/ViewModels/MainViewModel.cs
+++ b/demos/DemoApp.Net8/ViewModels/MainViewModel.cs
@@ -27,6 +27,7 @@ public sealed class MainViewModel
         Charts.Add(BuildSingleBars());          // 9
         Charts.Add(BuildStacked100());          //10
         Charts.Add(BuildOhlcWithErrorOverlay()); //11
+        Charts.Add(BuildMultiSeriesTooltipShowcase()); //12
     }
 
     private ChartModel CreateBase(DateTime start, DateTime end)
@@ -243,6 +244,30 @@ public sealed class MainViewModel
         m.AddSeries(new OhlcSeries(ohlc) { Title = "OHLC" });
         m.AddSeries(new ErrorBarSeries(errs) { Title = "Err" });
         m.UpdateScales(800, 400);
+        return m;
+    }
+
+    private ChartModel BuildMultiSeriesTooltipShowcase()
+    {
+        var start = DateTime.Today.AddDays(-3);
+        var end = DateTime.Today.AddDays(0.5);
+        var m = CreateBase(start, end);
+        // Dense line
+        var xs = Enumerable.Range(0, 300).Select(i => start.AddMinutes(i * 15)).ToArray();
+        var line = xs.Select((x,i) => new PointD(x.ToOADate(), 50 + Math.Sin(i * 0.15)*10 + Math.Sin(i*0.03)*5)).ToArray();
+        m.AddSeries(new LineSeries(line) { Title = "Line A", StrokeThickness = 1.4 });
+        // Area
+        var area = xs.Where((_,i)=> i%3==0).Select((x,i) => new PointD(x.ToOADate(), 40 + Math.Cos(i*0.18)*6)).ToArray();
+        m.AddSeries(new AreaSeries(area) { Title = "Area B", Baseline = 35, FillOpacity = 0.35 });
+        // Scatter sparse
+        var scatter = xs.Where((_,i)=> i%20==0).Select((x,i) => new PointD(x.ToOADate(), 55 + Math.Sin(i*0.9)*4)).ToArray();
+        m.AddSeries(new ScatterSeries(scatter) { Title = "Scatter C", MarkerSize = 4 });
+        // Bars daily
+        var dayXs = Enumerable.Range(0, 4).Select(i => start.AddDays(i)).ToArray();
+        var bars = dayXs.Select((x,i) => new BarPoint(x.ToOADate(), 30 + i*2 + Math.Sin(i)*3)).ToArray();
+        m.AddSeries(new BarSeries(bars) { Title = "Bars D", FillOpacity = 0.6 });
+        m.UpdateScales(800, 400);
+        // Note: ESC to unlock tooltip; click to lock/unlock already enabled by behavior.
         return m;
     }
 }

--- a/src/FastCharts.Core/Interaction/Behaviors/MultiSeriesTooltipBehavior.cs
+++ b/src/FastCharts.Core/Interaction/Behaviors/MultiSeriesTooltipBehavior.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.Linq;
+
 using FastCharts.Core.Series;
 
 namespace FastCharts.Core.Interaction.Behaviors
@@ -81,17 +82,22 @@ namespace FastCharts.Core.Interaction.Behaviors
                         break;
                     case BarSeries bar:
                         foreach (var p in bar.Data)
-                            if (Math.Abs(p.X - x) <= tol)
+                        {
+                            double halfW = bar.GetWidthFor(0) * 0.5; // approximate width; per-point width rarely varies
+                            if (Math.Abs(p.X - x) <= halfW) // use bar half-width instead of point tolerance
                                 st.TooltipSeries.Add(new TooltipSeriesValue { Title = bar.Title ?? "Bar", X = p.X, Y = p.Y, PaletteIndex = bar.PaletteIndex });
+                        }
                         break;
                     case StackedBarSeries sbar:
                         foreach (var p in sbar.Data)
-                            if (Math.Abs(p.X - x) <= tol && p.Values != null)
+                        {
+                            double halfW = sbar.GetWidthFor(0) * 0.5;
+                            if (Math.Abs(p.X - x) <= halfW && p.Values != null)
                             {
-                                double sum = 0;
-                                for (int i = 0; i < p.Values.Length; i++) sum += p.Values[i];
+                                double sum = 0; for (int i = 0; i < p.Values.Length; i++) sum += p.Values[i];
                                 st.TooltipSeries.Add(new TooltipSeriesValue { Title = sbar.Title ?? "Stack", X = p.X, Y = sum, PaletteIndex = sbar.PaletteIndex });
                             }
+                        }
                         break;
                     case OhlcSeries ohlc:
                         foreach (var p in ohlc.Data)

--- a/src/FastCharts.Rendering.Skia/SkiaChartRenderer.cs
+++ b/src/FastCharts.Rendering.Skia/SkiaChartRenderer.cs
@@ -134,17 +134,24 @@ namespace FastCharts.Rendering.Skia
             ctx.Canvas.DrawRect(rect, tipBg);
             ctx.Canvas.DrawRect(rect, tipBd);
             float ty = by + pad + tipTx.TextSize;
+            // Obtain font metrics once for vertical alignment
+            tipTx.GetFontMetrics(out var fm);
+            float textHeight = fm.Descent - fm.Ascent; // positive height
             for (int i = 0; i < lines.Length; i++)
             {
                 float tx = bx + pad;
-                if (showSwatches && i > 0 && i-1 < st.TooltipSeries.Count)
+                if (showSwatches && i > 0 && i - 1 < st.TooltipSeries.Count)
                 {
                     var sv = st.TooltipSeries[i - 1];
                     var col = model.Theme.PrimarySeriesColor;
                     if (sv.PaletteIndex.HasValue && model.Theme.SeriesPalette != null && sv.PaletteIndex.Value < model.Theme.SeriesPalette.Count)
                         col = model.Theme.SeriesPalette[sv.PaletteIndex.Value];
-                    using var sw = new SKPaint { Color = new SKColor(col.R,col.G,col.B,col.A), Style = SKPaintStyle.Fill, IsAntialias = true };
-                    var swRect = new SKRect(tx, ty - tipTx.TextSize, tx + swatchSize, ty - tipTx.TextSize + swatchSize);
+                    using var sw = new SKPaint { Color = new SKColor(col.R, col.G, col.B, col.A), Style = SKPaintStyle.Fill, IsAntialias = true };
+                    // Align swatch center with text middle (baseline + ascent gives top)
+                    float topText = ty + fm.Ascent; // ascent is negative
+                    float verticalPadding = (textHeight - swatchSize) * 0.5f;
+                    float swTop = topText + verticalPadding;
+                    var swRect = new SKRect(tx, swTop, tx + swatchSize, swTop + swatchSize);
                     ctx.Canvas.DrawRect(swRect, sw);
                     tx += swatchSize + swatchGap;
                 }


### PR DESCRIPTION
## Core Interaction:
•	InteractionState: TooltipSeries, TooltipLocked, TooltipAnchorX.
•	MultiSeriesTooltipBehavior: aggregates values (Line, Area, StepLine, Scatter, Bar, StackedBar (sum), OHLC (close), ErrorBar (Y)); click to lock/unlock.
## Rendering (Skia):
•	Multi-line tooltip with color swatches (aligned via font metrics).
## WPF FastChart:
•	Default behaviors include MultiSeriesTooltipBehavior.
•	ESC key unlocks locked tooltip and clears content.
## Demos:
•	Added MultiSeriesTooltipShowcase chart (Net8 + Net48) illustrating aggregation & ESC unlock.
•	Tests:
•	MultiSeriesTooltipBehaviorTests (aggregation + lock persistence).
## Fixes:
•	Bar/stacked bar hover tolerance uses full bar half-width (easier hit).
•	Swatch vertical alignment corrected.

#### No breaking API changes.