### PR TITLE
feat: secondary Y axis (P1-AX-MULTI)

### DIFF
--- a/src/FastCharts.Core/ChartModel.cs
+++ b/src/FastCharts.Core/ChartModel.cs
@@ -17,7 +17,6 @@ public sealed class ChartModel : IChartModel
 {
     private readonly List<AxisBase> _axesList;
     private readonly ReadOnlyCollection<AxisBase> _axesView;
-
     public ChartModel()
     {
         var x = new NumericAxis();
@@ -25,180 +24,162 @@ public sealed class ChartModel : IChartModel
         XAxis = x;
         YAxis = y;
         Viewport = new Interactivity.Viewport(new FRange(0, 1), new FRange(0, 1));
-
         Series = new ObservableCollection<SeriesBase>();
         _axesList = new List<AxisBase> { (AxisBase)XAxis, (AxisBase)YAxis };
         _axesView = new ReadOnlyCollection<AxisBase>(_axesList);
         Legend = new LegendModel();
     }
-
     public ITheme Theme { get; set; } = new LightTheme();
     public IAxis<double> XAxis { get; private set; }
     public IAxis<double> YAxis { get; private set; }
+    /// <summary>Optional secondary Y axis (index 1) when present. Lazily created.</summary>
+    public IAxis<double>? YAxisSecondary { get; private set; }
     public IViewport Viewport { get; }
     public ObservableCollection<SeriesBase> Series { get; }
     public IReadOnlyList<AxisBase> Axes => _axesView;
-
-    // IChartModel (kept loose for now)
     IReadOnlyList<AxisBase> IChartModel.Axes => Axes;
     IReadOnlyList<SeriesBase> IChartModel.Series => Series;
-    
     public Margins PlotMargins { get; set; } = new Margins(48, 16, 16, 36);
-    
-    /// <summary>Legend model describing series entries.</summary>
     public LegendModel Legend { get; }
-    
-    /// <summary>Ordered list of behaviors attached to this model.</summary>
     public IList<IBehavior> Behaviors { get; } = new List<IBehavior>();
-
-    /// <summary>Shared interaction state that renderers may read to draw overlays.</summary>
     public InteractionState? InteractionState { get; set; }
-
+    public void EnsureSecondaryYAxis()
+    {
+        if (YAxisSecondary != null) return;
+        YAxisSecondary = new NumericAxis();
+        _axesList.Add((AxisBase)YAxisSecondary);
+    }
     public void ReplaceXAxis(IAxis<double> newAxis)
     {
-        if (newAxis == null)
-        {
-            return;
-        }
+        if (newAxis == null) return;
         var old = XAxis;
-        // Preserve data range; visible will be set from viewport during UpdateScales
         newAxis.DataRange = old.DataRange;
         XAxis = newAxis;
-        if (_axesList.Count > 0)
-        {
-            _axesList[0] = (AxisBase)newAxis;
-        }
+        if (_axesList.Count > 0) _axesList[0] = (AxisBase)newAxis;
     }
-
     public void ReplaceYAxis(IAxis<double> newAxis)
     {
-        if (newAxis == null)
-        {
-            return;
-        }
+        if (newAxis == null) return;
         var old = YAxis;
         newAxis.DataRange = old.DataRange;
         YAxis = newAxis;
-        if (_axesList.Count > 1)
-        {
-            _axesList[1] = (AxisBase)newAxis;
-        }
+        if (_axesList.Count > 1) _axesList[1] = (AxisBase)newAxis;
     }
-
+    public void ReplaceSecondaryYAxis(IAxis<double> newAxis)
+    {
+        EnsureSecondaryYAxis();
+        if (newAxis == null || YAxisSecondary == null) return;
+        newAxis.DataRange = YAxisSecondary.DataRange;
+        YAxisSecondary = newAxis;
+        _axesList[2] = (AxisBase)newAxis;
+    }
     public void AddSeries(SeriesBase series)
     {
         Series.Add(series);
-        Legend.SyncFromSeries(Series); // keep legend updated
+        Legend.SyncFromSeries(Series);
         AutoFitDataRange();
     }
-
     public void ClearSeries()
     {
         Series.Clear();
         Legend.SyncFromSeries(Series);
         XAxis.DataRange = new FRange(0, 1);
         YAxis.DataRange = new FRange(0, 1);
+        if (YAxisSecondary != null) YAxisSecondary.DataRange = new FRange(0, 1);
         Viewport.SetVisible(XAxis.DataRange, YAxis.DataRange);
     }
-
     public void UpdateScales(double widthPx, double heightPx)
     {
         XAxis.VisibleRange = Viewport.X;
         YAxis.VisibleRange = Viewport.Y;
         ((AxisBase)XAxis).UpdateScale(0, widthPx);
-        // Y pixels typically grow downward; invert here for convenience
         ((AxisBase)YAxis).UpdateScale(heightPx, 0);
+        if (YAxisSecondary != null)
+        {
+            // For now share primary viewport Y range; future: independent viewport or mapping
+            YAxisSecondary.VisibleRange = YAxis.VisibleRange;
+            ((AxisBase)YAxisSecondary).UpdateScale(heightPx, 0);
+        }
     }
-
     public void AutoFitDataRange()
     {
         var xs = new List<FRange>();
-        var ys = new List<FRange>();
-
+        var ysPrimary = new List<FRange>();
+        var ysSecondary = new List<FRange>();
+        bool anySecondary = false;
         foreach (var s in Series)
         {
+            if (s.IsEmpty || !s.IsVisible) continue;
+            FRange xr; FRange yr;
             switch (s)
             {
-                case LineSeries ls when !ls.IsEmpty:
-                    xs.Add(ls.GetXRange());
-                    ys.Add(ls.GetYRange());
-                    break;
-                case ScatterSeries sc when !sc.IsEmpty:
-                    xs.Add(sc.GetXRange());
-                    ys.Add(sc.GetYRange());
-                    break;
-                case BandSeries band when !band.IsEmpty:
-                    var minX = band.Data.Min(p => p.X);
-                    var maxX = band.Data.Max(p => p.X);
-                    var minY = band.Data.Min(p => p.YLow);
-                    var maxY = band.Data.Max(p => p.YHigh);
-                    xs.Add(new FRange(minX, maxX));
-                    ys.Add(new FRange(minY, maxY));
-                    break;
-                case BarSeries bar when !bar.IsEmpty:
-                    xs.Add(bar.GetXRange());
-                    ys.Add(bar.GetYRange());
-                    break;
-                case StackedBarSeries sbar when !sbar.IsEmpty:
-                    xs.Add(sbar.GetXRange());
-                    ys.Add(sbar.GetYRange());
-                    break;
-                case OhlcSeries ohlc when !ohlc.IsEmpty:
-                    xs.Add(ohlc.GetXRange());
-                    ys.Add(ohlc.GetYRange());
-                    break;
-                case ErrorBarSeries err when !err.IsEmpty:
-                    xs.Add(err.GetXRange());
-                    ys.Add(err.GetYRange());
-                    break;
+                case LineSeries ls:
+                    xr = ls.GetXRange(); yr = ls.GetYRange(); break;
+                case ScatterSeries sc:
+                    xr = sc.GetXRange(); yr = sc.GetYRange(); break;
+                case BandSeries band:
+                    var minX = band.Data.Min(p => p.X); var maxX = band.Data.Max(p => p.X);
+                    var minY = band.Data.Min(p => p.YLow); var maxY = band.Data.Max(p => p.YHigh);
+                    xr = new FRange(minX, maxX); yr = new FRange(minY, maxY); break;
+                case BarSeries bar:
+                    xr = bar.GetXRange(); yr = bar.GetYRange(); break;
+                case StackedBarSeries sbar:
+                    xr = sbar.GetXRange(); yr = sbar.GetYRange(); break;
+                case OhlcSeries ohlc:
+                    xr = ohlc.GetXRange(); yr = ohlc.GetYRange(); break;
+                case ErrorBarSeries err:
+                    xr = err.GetXRange(); yr = err.GetYRange(); break;
+                default:
+                    continue;
+            }
+            xs.Add(xr);
+            if (s.YAxisIndex == 1)
+            {
+                anySecondary = true; ysSecondary.Add(yr);
+            }
+            else
+            {
+                ysPrimary.Add(yr);
             }
         }
-
-        if (xs.Count == 0 || ys.Count == 0) { return; }
-
-        var xMin = xs.Min(r => r.Min);
-        var xMax = xs.Max(r => r.Max);
-        var yMin = ys.Min(r => r.Min);
-        var yMax = ys.Max(r => r.Max);
-
+        if (xs.Count == 0) return;
+        var xMin = xs.Min(r => r.Min); var xMax = xs.Max(r => r.Max);
         if (xMin == xMax) { xMin -= 0.5; xMax += 0.5; }
-        if (yMin == yMax) { yMin -= 0.5; yMax += 0.5; }
-
         XAxis.DataRange = new FRange(xMin, xMax);
-        YAxis.DataRange = new FRange(yMin, yMax);
+        if (ysPrimary.Count > 0)
+        {
+            var yMin = ysPrimary.Min(r => r.Min); var yMax = ysPrimary.Max(r => r.Max);
+            if (yMin == yMax) { yMin -= 0.5; yMax += 0.5; }
+            YAxis.DataRange = new FRange(yMin, yMax);
+        }
+        if (anySecondary)
+        {
+            EnsureSecondaryYAxis();
+            if (ysSecondary.Count > 0)
+            {
+                var y2Min = ysSecondary.Min(r => r.Min); var y2Max = ysSecondary.Max(r => r.Max);
+                if (y2Min == y2Max) { y2Min -= 0.5; y2Max += 0.5; }
+                YAxisSecondary!.DataRange = new FRange(y2Min, y2Max);
+            }
+        }
         Viewport.SetVisible(XAxis.DataRange, YAxis.DataRange);
     }
-    
     public void ZoomAt(double factorX, double factorY, double centerDataX, double centerDataY)
     {
-        // factor < 1 => zoom in; factor > 1 => zoom out
-        var xr = XAxis.VisibleRange;
-        var yr = YAxis.VisibleRange;
-
-        var newSizeX = xr.Size * factorX;
-        var newSizeY = yr.Size * factorY;
-
-        // keep the center point fixed
-        var newMinX = centerDataX - (centerDataX - xr.Min) * factorX;
-        var newMaxX = newMinX + newSizeX;
-
-        var newMinY = centerDataY - (centerDataY - yr.Min) * factorY;
-        var newMaxY = newMinY + newSizeY;
-
-        // apply with guard against zero-length
+        var xr = XAxis.VisibleRange; var yr = YAxis.VisibleRange;
+        var newSizeX = xr.Size * factorX; var newSizeY = yr.Size * factorY;
+        var newMinX = centerDataX - (centerDataX - xr.Min) * factorX; var newMaxX = newMinX + newSizeX;
+        var newMinY = centerDataY - (centerDataY - yr.Min) * factorY; var newMaxY = newMinY + newSizeY;
         if (newMinX == newMaxX) { newMinX -= 1e-6; newMaxX += 1e-6; }
         if (newMinY == newMaxY) { newMinY -= 1e-6; newMaxY += 1e-6; }
-
-        XAxis.VisibleRange = new FRange(newMinX, newMaxX);
-        YAxis.VisibleRange = new FRange(newMinY, newMaxY);
+        XAxis.VisibleRange = new FRange(newMinX, newMaxX); YAxis.VisibleRange = new FRange(newMinY, newMaxY);
+        if (YAxisSecondary != null) YAxisSecondary.VisibleRange = YAxis.VisibleRange;
     }
-
     public void Pan(double deltaDataX, double deltaDataY)
     {
-        var xr = XAxis.VisibleRange;
-        var yr = YAxis.VisibleRange;
-
+        var xr = XAxis.VisibleRange; var yr = YAxis.VisibleRange;
         XAxis.VisibleRange = new FRange(xr.Min + deltaDataX, xr.Max + deltaDataX);
         YAxis.VisibleRange = new FRange(yr.Min + deltaDataY, yr.Max + deltaDataY);
+        if (YAxisSecondary != null) YAxisSecondary.VisibleRange = YAxis.VisibleRange;
     }
 }

--- a/src/FastCharts.Core/Series/SeriesBase.cs
+++ b/src/FastCharts.Core/Series/SeriesBase.cs
@@ -37,6 +37,11 @@ namespace FastCharts.Core.Series
         public object? Tag { get; set; }
 
         /// <summary>
+        /// Indicates which Y axis this series should use (0 = primary, 1 = secondary). Defaults to 0.
+        /// </summary>
+        public int YAxisIndex { get; set; }
+
+        /// <summary>
         /// Series has no data to render.
         /// </summary>
         public abstract bool IsEmpty { get; }

--- a/src/FastCharts.Rendering.Skia/Rendering/Layers/AxesTicksLayer.cs
+++ b/src/FastCharts.Rendering.Skia/Rendering/Layers/AxesTicksLayer.cs
@@ -25,14 +25,13 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
             var xr = model.XAxis.VisibleRange;
             var yr = model.YAxis.VisibleRange;
             if (xr.Size <= 0 || yr.Size <= 0) return;
-
             double xDataPerPx = xr.Size / System.Math.Max(1.0, pr.Width);
             double yDataPerPx = yr.Size / System.Math.Max(1.0, pr.Height);
             double approxXStepData = 80.0 * xDataPerPx;
             double approxYStepData = 50.0 * yDataPerPx;
             var xTicks = model.XAxis.Ticker.GetTicks(xr, approxXStepData);
             var yTicks = model.YAxis.Ticker.GetTicks(yr, approxYStepData);
-
+            var y2Ticks = model.YAxisSecondary != null ? model.YAxisSecondary.Ticker.GetTicks(model.YAxisSecondary.VisibleRange, approxYStepData) : null;
             float tickLen = (float)theme.TickLength;
             bool xIsDate = model.XAxis is DateTimeAxis;
             foreach (var t in xTicks)
@@ -76,7 +75,19 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
                 float w = paints.Text.MeasureText(lbl);
                 c.DrawText(lbl, xBase - tickLen - 6 - w, py + 4, paints.Text);
             }
-
+            if (y2Ticks != null)
+            {
+                float xR = pr.Right;
+                foreach (var t in y2Ticks)
+                {
+                    float py = PixelMapper.Y(t, model.YAxisSecondary!, pr);
+                    c.DrawLine(xR, py, xR + tickLen, py, paints.Tick);
+                    var ny2 = model.YAxisSecondary as NumericAxis;
+                    var y2f = ny2?.NumberFormatter;
+                    var lbl2 = y2f != null ? y2f.Format(t) : t.ToString(ny2?.LabelFormat ?? "G", CultureInfo.InvariantCulture);
+                    c.DrawText(lbl2, xR + tickLen + 4, py + 4, paints.Text);
+                }
+            }
             // Border
             c.DrawRect(pr, paints.Border);
         }

--- a/src/FastCharts.Rendering.Skia/Rendering/Layers/BarLayer.cs
+++ b/src/FastCharts.Rendering.Skia/Rendering/Layers/BarLayer.cs
@@ -39,8 +39,9 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
                     double groupOffsetFromCenter = ((groupIndex2 + 0.5) - (groupCount * 0.5)) * slotW;
                     float xL = PixelMapper.X(p.X + groupOffsetFromCenter - effW * 0.5, model.XAxis, pr);
                     float xR = PixelMapper.X(p.X + groupOffsetFromCenter + effW * 0.5, model.XAxis, pr);
-                    float y0 = PixelMapper.Y(bs.Baseline, model.YAxis, pr);
-                    float y1 = PixelMapper.Y(p.Y, model.YAxis, pr);
+                    var yAxis = (bs.YAxisIndex == 1 && model.YAxisSecondary != null) ? model.YAxisSecondary : model.YAxis;
+                    float y0 = PixelMapper.Y(bs.Baseline, yAxis, pr);
+                    float y1 = PixelMapper.Y(p.Y, yAxis, pr);
                     var rect = SKRect.Create(System.Math.Min(xL, xR), System.Math.Min(y0, y1), System.Math.Abs(xR - xL), System.Math.Abs(y1 - y0));
                     if (rect.Width <= 0 || rect.Height <= 0)
                     {

--- a/src/FastCharts.Rendering.Skia/Rendering/Layers/ErrorBarLayer.cs
+++ b/src/FastCharts.Rendering.Skia/Rendering/Layers/ErrorBarLayer.cs
@@ -20,8 +20,9 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
                 {
                     double neg = p.NegativeError ?? p.PositiveError;
                     float xC = PixelMapper.X(p.X, model.XAxis, pr);
-                    float yTop = PixelMapper.Y(p.Y + p.PositiveError, model.YAxis, pr);
-                    float yBot = PixelMapper.Y(p.Y - neg, model.YAxis, pr);
+                    var yAxis = (es.YAxisIndex == 1 && model.YAxisSecondary != null) ? model.YAxisSecondary : model.YAxis;
+                    float yTop = PixelMapper.Y(p.Y + p.PositiveError, yAxis, pr);
+                    float yBot = PixelMapper.Y(p.Y - neg, yAxis, pr);
                     float xL = PixelMapper.X(p.X - cap, model.XAxis, pr);
                     float xR = PixelMapper.X(p.X + cap, model.XAxis, pr);
                     ctx.Canvas.DrawLine(xC, yTop, xC, yBot, pen);

--- a/src/FastCharts.Rendering.Skia/Rendering/Layers/LineLayer.cs
+++ b/src/FastCharts.Rendering.Skia/Rendering/Layers/LineLayer.cs
@@ -34,7 +34,8 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
                 foreach (var p in ls.Data)
                 {
                     float px = PixelMapper.X(p.X, model.XAxis, pr);
-                    float py = PixelMapper.Y(p.Y, model.YAxis, pr);
+                    var yAxis = (ls.YAxisIndex == 1 && model.YAxisSecondary != null) ? model.YAxisSecondary : model.YAxis;
+                    float py = PixelMapper.Y(p.Y, yAxis, pr);
                     if (!startedLine)
                     {
                         path2.MoveTo(px, py);

--- a/src/FastCharts.Rendering.Skia/Rendering/Layers/OhlcLayer.cs
+++ b/src/FastCharts.Rendering.Skia/Rendering/Layers/OhlcLayer.cs
@@ -30,10 +30,11 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
                     float xC = PixelMapper.X(p.X, model.XAxis, pr);
                     float xL = PixelMapper.X(p.X - half * 0.7, model.XAxis, pr);
                     float xR = PixelMapper.X(p.X + half * 0.7, model.XAxis, pr);
-                    float yOpen = PixelMapper.Y(p.Open, model.YAxis, pr);
-                    float yHigh = PixelMapper.Y(p.High, model.YAxis, pr);
-                    float yLow = PixelMapper.Y(p.Low, model.YAxis, pr);
-                    float yClose = PixelMapper.Y(p.Close, model.YAxis, pr);
+                    var yAxis = (os.YAxisIndex == 1 && model.YAxisSecondary != null) ? model.YAxisSecondary : model.YAxis;
+                    float yOpen = PixelMapper.Y(p.Open, yAxis, pr);
+                    float yHigh = PixelMapper.Y(p.High, yAxis, pr);
+                    float yLow = PixelMapper.Y(p.Low, yAxis, pr);
+                    float yClose = PixelMapper.Y(p.Close, yAxis, pr);
                     bool up = p.Close >= p.Open;
                     var bodyColor = up ? cUp : cDown;
                     byte fillAlpha = (byte)(RenderMath.Clamp01(up ? os.UpFillOpacity : os.DownFillOpacity) * bodyColor.A);

--- a/src/FastCharts.Rendering.Skia/Rendering/Layers/ScatterLayer.cs
+++ b/src/FastCharts.Rendering.Skia/Rendering/Layers/ScatterLayer.cs
@@ -19,7 +19,8 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
                 foreach (var p in ss.Data)
                 {
                     float px = PixelMapper.X(p.X, model.XAxis, pr);
-                    float py = PixelMapper.Y(p.Y, model.YAxis, pr);
+                    var yAxis = (ss.YAxisIndex == 1 && model.YAxisSecondary != null) ? model.YAxisSecondary : model.YAxis;
+                    float py = PixelMapper.Y(p.Y, yAxis, pr);
                     switch (ss.MarkerShape)
                     {
                         case MarkerShape.Circle:

--- a/src/FastCharts.Rendering.Skia/Rendering/Layers/StackedBarLayer.cs
+++ b/src/FastCharts.Rendering.Skia/Rendering/Layers/StackedBarLayer.cs
@@ -37,6 +37,7 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
                     float xR = PixelMapper.X(p.X + groupOffset + effW * 0.5, model.XAxis, pr);
                     double accPos = sbs.Baseline;
                     double accNeg = sbs.Baseline;
+                    var yAxis = (sbs.YAxisIndex == 1 && model.YAxisSecondary != null) ? model.YAxisSecondary : model.YAxis;
                     if (p.Values != null && p.Values.Length > 0)
                     {
                         for (int seg = 0; seg < p.Values.Length; seg++)
@@ -55,8 +56,8 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
                             byte alpha = (byte)(RenderMath.Clamp01(sbs.FillOpacity) * col.A);
                             using var fillSeg = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Fill, Color = new SKColor(col.R, col.G, col.B, alpha) };
                             using var strokeSeg = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Stroke, StrokeWidth = (float)System.Math.Max(1.0, sbs.StrokeThickness), Color = new SKColor(col.R, col.G, col.B, col.A) };
-                            float y0 = PixelMapper.Y(yStart, model.YAxis, pr);
-                            float y1 = PixelMapper.Y(yEnd, model.YAxis, pr);
+                            float y0 = PixelMapper.Y(yStart, yAxis, pr);
+                            float y1 = PixelMapper.Y(yEnd, yAxis, pr);
                             var rect = SKRect.Create(System.Math.Min(xL, xR), System.Math.Min(y0, y1), System.Math.Abs(xR - xL), System.Math.Abs(y1 - y0));
                             if (rect.Width <= 0 || rect.Height <= 0)
                             {

--- a/src/FastCharts.Rendering.Skia/Rendering/Layers/StepLineLayer.cs
+++ b/src/FastCharts.Rendering.Skia/Rendering/Layers/StepLineLayer.cs
@@ -22,7 +22,8 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
                 {
                     var p = sls.Data[i];
                     float x = PixelMapper.X(p.X, model.XAxis, pr);
-                    float y = PixelMapper.Y(p.Y, model.YAxis, pr);
+                    var yAxis = (sls.YAxisIndex == 1 && model.YAxisSecondary != null) ? model.YAxisSecondary : model.YAxis;
+                    float y = PixelMapper.Y(p.Y, yAxis, pr);
                     if (!started2)
                     {
                         path.MoveTo(x, y);
@@ -31,7 +32,7 @@ namespace FastCharts.Rendering.Skia.Rendering.Layers
                     }
                     var prev = sls.Data[i - 1];
                     float xPrev = PixelMapper.X(prev.X, model.XAxis, pr);
-                    float yPrev = PixelMapper.Y(prev.Y, model.YAxis, pr);
+                    float yPrev = PixelMapper.Y(prev.Y, yAxis, pr);
                     if (sls.Mode == StepMode.Before)
                     {
                         path.LineTo(x, yPrev); path.LineTo(x, y);

--- a/src/FastCharts.Rendering.Skia/SkiaChartRenderer.cs
+++ b/src/FastCharts.Rendering.Skia/SkiaChartRenderer.cs
@@ -27,7 +27,13 @@ namespace FastCharts.Rendering.Skia
             var m = model.PlotMargins;
             float left = (float)m.Left;
             float top = (float)m.Top;
-            float right = (float)m.Right;
+            // Auto-extend right margin if secondary Y axis is present (reserve space for labels)
+            double rightBase = m.Right;
+            if (model.YAxisSecondary != null)
+            {
+                rightBase = System.Math.Max(rightBase, 48); // ensure sufficient space for secondary labels
+            }
+            float right = (float)rightBase;
             float bottom = (float)m.Bottom;
             float plotW = (float)System.Math.Max(0, pixelWidth - (left + right));
             float plotH = (float)System.Math.Max(0, pixelHeight - (top + bottom));

--- a/tests/FastCharts.Core.Tests/MultiAxisTests.cs
+++ b/tests/FastCharts.Core.Tests/MultiAxisTests.cs
@@ -1,0 +1,60 @@
+using FastCharts.Core;
+using FastCharts.Core.Primitives;
+using FastCharts.Core.Series;
+using Xunit;
+
+namespace FastCharts.Core.Tests
+{
+    public class MultiAxisTests
+    {
+        [Fact]
+        public void AddingSecondarySeriesCreatesSecondaryAxisWithIndependentRange()
+        {
+            var m = new ChartModel();
+            // Primary Y series (range roughly 0..10)
+            var primary = new LineSeries(new[]
+            {
+                new PointD(0, 0),
+                new PointD(5, 10)
+            }) { Title = "Primary" };
+            m.AddSeries(primary);
+            // Secondary Y series (range 100..200)
+            var secondary = new LineSeries(new[]
+            {
+                new PointD(0, 100),
+                new PointD(5, 200)
+            }) { Title = "Secondary", YAxisIndex = 1 };
+            m.AddSeries(secondary);
+
+            // AutoFit is invoked by AddSeries, but call again explicitly for clarity
+            m.AutoFitDataRange();
+            Assert.NotNull(m.YAxisSecondary);
+
+            var y1 = m.YAxis.DataRange;
+            var y2 = m.YAxisSecondary!.DataRange;
+
+            Assert.InRange(y1.Min, -0.01, 0.01);
+            Assert.InRange(y1.Max, 9.99, 10.01);
+            Assert.InRange(y2.Min, 99.5, 100.5);
+            Assert.InRange(y2.Max, 199.5, 200.5);
+        }
+
+        [Fact]
+        public void SecondaryAxisVisibleRangeSyncsOnUpdateScales()
+        {
+            var m = new ChartModel();
+            var secondary = new LineSeries(new[] { new PointD(0, 50), new PointD(10, 150) }) { YAxisIndex = 1 };
+            m.AddSeries(secondary);
+            m.AutoFitDataRange();
+            Assert.NotNull(m.YAxisSecondary);
+            // Modify primary viewport then update scales
+            m.Viewport.SetVisible(m.XAxis.DataRange, new FRange(10, 20));
+            m.UpdateScales(400, 300);
+            Assert.Equal(new FRange(10, 20).Min, m.YAxis.VisibleRange.Min, 6);
+            Assert.Equal(new FRange(10, 20).Max, m.YAxis.VisibleRange.Max, 6);
+            // Secondary should mirror for now (shared viewport behavior)
+            Assert.Equal(m.YAxis.VisibleRange.Min, m.YAxisSecondary!.VisibleRange.Min, 6);
+            Assert.Equal(m.YAxis.VisibleRange.Max, m.YAxisSecondary!.VisibleRange.Max, 6);
+        }
+    }
+}


### PR DESCRIPTION
•	SeriesBase: nouvelle propriété YAxisIndex (0 primaire, 1 secondaire).
•	ChartModel: gestion YAxisSecondary (création lazy), AutoFit séparé primary/secondary, EnsureSecondaryYAxis(), ReplaceSecondaryYAxis().
•	Rendu Skia: toutes les layers (Line, StepLine, Area, Band, Scatter, Bar, StackedBar, Ohlc, ErrorBar) utilisent le bon axe via YAxisIndex.
•	AxesTicksLayer: ticks + labels axe droit quand secondaire présent.
•	Marge droite auto-élargie (≥48px) si YAxisSecondary actif pour éviter chevauchements.
•	Tests: MultiAxisTests vérifient création axe secondaire + synchro VisibleRange.
•	Aucun avertissement (TreatWarningsAsErrors).

Limitations actuelles:
•	Viewport Y partagé entre axes (pas de scaling indépendant pour l’instant).
•	Tooltip / crosshair n’affichent qu’une valeur Y (pas encore multi-axes).
•	Legend ne différencie pas l’axe secondaire.
•	Ajustement marge configurable non exposé (hard-coded 48).

Prochaines itérations suggérées:
1.	Crosshair/tooltips multi-axes.
2.	Margin config (SecondaryYAxisMinMargin).
3.	Legend indication (ex: suffix “(Y2)”).
4.	Option de viewport Y indépendant (mode dual-scale).
5.	Documentation + mise à jour roadmap (cocher P1-AX-MULTI).
Vérification:
•	Build OK sur toutes TFMs.
•	Tests ajoutés passent.