### PR TITLE
feat: PNG export (P1-EXPORT-PNG)

### DIFF
--- a/src/FastCharts.Rendering.Skia/SkiaChartRenderer.cs
+++ b/src/FastCharts.Rendering.Skia/SkiaChartRenderer.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Linq;
 using FastCharts.Core;
 using FastCharts.Core.Abstractions;
@@ -17,6 +18,10 @@ namespace FastCharts.Rendering.Skia
         private readonly AxesTicksLayer _axesTicks = new();
         private readonly LegendLayer _legend = new();
 
+        /// <summary>
+        /// Render the chart model onto a provided SKCanvas of given pixel size.
+        /// The caller owns the canvas lifecycle.
+        /// </summary>
         public void Render(ChartModel model, SKCanvas canvas, int pixelWidth, int pixelHeight)
         {
             if (model == null || canvas == null)
@@ -51,70 +56,74 @@ namespace FastCharts.Rendering.Skia
             RenderOverlay(ctx);
         }
 
+        /// <summary>
+        /// Renders the chart into a new SKBitmap (caller must dispose) with optional transparency.
+        /// </summary>
+        public SKBitmap RenderToBitmap(ChartModel model, int pixelWidth, int pixelHeight, bool transparentBackground = false)
+        {
+            var info = new SKImageInfo(pixelWidth, pixelHeight, SKColorType.Bgra8888, SKAlphaType.Premul);
+            var bmp = new SKBitmap(info);
+            using var canvas = new SKCanvas(bmp);
+            if (transparentBackground)
+            {
+                canvas.Clear(SKColors.Transparent);
+            }
+            Render(model, canvas, pixelWidth, pixelHeight);
+            canvas.Flush();
+            return bmp;
+        }
+
+        /// <summary>
+        /// Exports the chart as PNG into a stream. Stream must be writable.
+        /// </summary>
+        public void ExportPng(ChartModel model, Stream destination, int pixelWidth, int pixelHeight, int quality = 100, bool transparentBackground = false)
+        {
+            if (model == null || destination == null || !destination.CanWrite)
+            {
+                return;
+            }
+            using var bmp = RenderToBitmap(model, pixelWidth, pixelHeight, transparentBackground);
+            using var img = SKImage.FromPixels(bmp.PeekPixels());
+            // quality not used for PNG (lossless) but kept for potential future JPEG/WebP overload
+            using var data = img.Encode(SKEncodedImageFormat.Png, quality);
+            data.SaveTo(destination);
+            destination.Flush();
+        }
+
         private static void RenderOverlay(RenderContext ctx)
         {
             var model = ctx.Model;
             var pr = ctx.PlotRect;
             var st = model.InteractionState;
-            if (st == null)
-            {
-                return;
-            }
-            var tooltipSeries = st.TooltipSeries; // local snapshot
-            if (tooltipSeries == null)
-            {
-                return;
-            }
-
-            // Selection rectangle
+            if (st == null) { return; }
+            var tooltipSeries = st.TooltipSeries;
+            if (tooltipSeries == null) { return; }
             if (st.ShowSelectionRect)
             {
                 float x1 = (float)st.SelX1, y1 = (float)st.SelY1, x2 = (float)st.SelX2, y2 = (float)st.SelY2;
                 using var selFill = new SKPaint { Color = new SKColor(30, 120, 220, 40), Style = SKPaintStyle.Fill, IsAntialias = true };
                 using var selStroke = new SKPaint { Color = new SKColor(30, 120, 220, 160), Style = SKPaintStyle.Stroke, StrokeWidth = 1, IsAntialias = true };
                 var rr = SKRect.Create(System.Math.Min(x1, x2), System.Math.Min(y1, y2), System.Math.Abs(x2 - x1), System.Math.Abs(y2 - y1));
-                ctx.Canvas.Save();
-                ctx.Canvas.ClipRect(pr);
-                ctx.Canvas.DrawRect(rr, selFill);
-                ctx.Canvas.DrawRect(rr, selStroke);
-                ctx.Canvas.Restore();
+                ctx.Canvas.Save(); ctx.Canvas.ClipRect(pr); ctx.Canvas.DrawRect(rr, selFill); ctx.Canvas.DrawRect(rr, selStroke); ctx.Canvas.Restore();
             }
-
-            // Nearest-point highlight
             if (st.ShowNearest)
             {
                 float px = PixelMapper.X(st.NearestDataX, ctx.Model.XAxis, pr);
                 float py = PixelMapper.Y(st.NearestDataY, ctx.Model.YAxis, pr);
                 using var npStroke = new SKPaint { Color = new SKColor(255, 80, 80, 220), Style = SKPaintStyle.Stroke, StrokeWidth = 2, IsAntialias = true };
                 using var npFill = new SKPaint { Color = new SKColor(255, 80, 80, 120), Style = SKPaintStyle.Fill, IsAntialias = true };
-                ctx.Canvas.Save();
-                ctx.Canvas.ClipRect(pr);
-                ctx.Canvas.DrawCircle(px, py, 6, npFill);
-                ctx.Canvas.DrawCircle(px, py, 6, npStroke);
-                ctx.Canvas.Restore();
+                ctx.Canvas.Save(); ctx.Canvas.ClipRect(pr); ctx.Canvas.DrawCircle(px, py, 6, npFill); ctx.Canvas.DrawCircle(px, py, 6, npStroke); ctx.Canvas.Restore();
             }
-
-            if (!st.ShowCrosshair)
-            {
-                return;
-            }
-
-            float cx = (float)st.PixelX;
-            float cy = (float)st.PixelY;
-            if (cx < pr.Left) { cx = pr.Left; } else if (cx > pr.Right) { cx = pr.Right; }
-            if (cy < pr.Top) { cy = pr.Top; } else if (cy > pr.Bottom) { cy = pr.Bottom; }
-
-            using var cross = new SKPaint { Color = new SKColor(0, 0, 0, 80), Style = SKPaintStyle.Stroke, StrokeWidth = 1, IsAntialias = false };
+            if (!st.ShowCrosshair) { return; }
+            float cx = (float)st.PixelX; float cy = (float)st.PixelY;
+            if (cx < pr.Left) cx = pr.Left; else if (cx > pr.Right) cx = pr.Right;
+            if (cy < pr.Top) cy = pr.Top; else if (cy > pr.Bottom) cy = pr.Bottom;
+            using var cross = new SKPaint { Color = new SKColor(0, 0, 0, 80), Style = SKPaintStyle.Stroke, StrokeWidth = 1 };
             using var tipBg = new SKPaint { Color = new SKColor(255, 255, 255, 230), Style = SKPaintStyle.Fill, IsAntialias = true };
             using var tipBd = new SKPaint { Color = new SKColor(0, 0, 0, 120), Style = SKPaintStyle.Stroke, StrokeWidth = 1, IsAntialias = true };
             using var tipTx = new SKPaint { Color = new SKColor(30, 30, 30, 255), Style = SKPaintStyle.Fill, IsAntialias = true, TextSize = (float)model.Theme.LabelTextSize };
-            var palette = model.Theme.SeriesPalette; // cache palette (may be null)
-            ctx.Canvas.Save();
-            ctx.Canvas.ClipRect(pr);
-            ctx.Canvas.DrawLine(pr.Left, cy, pr.Right, cy, cross);
-            ctx.Canvas.DrawLine(cx, pr.Top, cx, pr.Bottom, cross);
-            ctx.Canvas.Restore();
-            // Prefer aggregated multi-series tooltip
+            var palette = model.Theme.SeriesPalette;
+            ctx.Canvas.Save(); ctx.Canvas.ClipRect(pr); ctx.Canvas.DrawLine(pr.Left, cy, pr.Right, cy, cross); ctx.Canvas.DrawLine(cx, pr.Top, cx, pr.Bottom, cross); ctx.Canvas.Restore();
             string[] lines;
             if (tooltipSeries.Count > 0)
             {
@@ -126,69 +135,31 @@ namespace FastCharts.Rendering.Skia
             {
                 lines = (st.TooltipText ?? string.Empty).Split('\n');
             }
-            else
-            {
-                return;
-            }
-            float maxW = 0;
-            foreach (var l in lines)
-            {
-                float w = tipTx.MeasureText(l);
-                if (w > maxW)
-                {
-                    maxW = w;
-                }
-            }
-            float lineH = tipTx.TextSize + 2;
-            float pad = 6;
-            bool showSwatches = tooltipSeries.Count > 0;
-            float swatchSize = showSwatches ? tipTx.TextSize * 0.6f : 0f;
-            float swatchGap = showSwatches ? 4f : 0f;
-            float extra = showSwatches ? (swatchSize + swatchGap) : 0f;
-            float boxW = maxW + pad * 2 + extra;
-            float boxH = lineH * lines.Length + pad * 2;
-            float bx = cx + 12;
-            float by = cy - boxH - 12;
-            if (bx + boxW > pr.Right) { bx = pr.Right - boxW - 1; }
-            if (by < pr.Top) { by = cy + 12; }
-            var rect = new SKRect(bx, by, bx + boxW, by + boxH);
-            ctx.Canvas.DrawRect(rect, tipBg);
-            ctx.Canvas.DrawRect(rect, tipBd);
-            float ty = by + pad + tipTx.TextSize;
-            // Obtain font metrics once for vertical alignment
-            tipTx.GetFontMetrics(out var fm);
-            float textHeight = fm.Descent - fm.Ascent; // positive height
+            else { return; }
+            float maxW = 0; foreach (var l in lines) { float w = tipTx.MeasureText(l); if (w > maxW) maxW = w; }
+            float lineH = tipTx.TextSize + 2; float pad = 6; bool showSwatches = tooltipSeries.Count > 0; float swatchSize = showSwatches ? tipTx.TextSize * 0.6f : 0f; float swatchGap = showSwatches ? 4f : 0f; float extra = showSwatches ? (swatchSize + swatchGap) : 0f;
+            float boxW = maxW + pad * 2 + extra; float boxH = lineH * lines.Length + pad * 2; float bx = cx + 12; float by = cy - boxH - 12; if (bx + boxW > pr.Right) bx = pr.Right - boxW - 1; if (by < pr.Top) by = cy + 12;
+            var rect = new SKRect(bx, by, bx + boxW, by + boxH); ctx.Canvas.DrawRect(rect, tipBg); ctx.Canvas.DrawRect(rect, tipBd);
+            float ty = by + pad + tipTx.TextSize; tipTx.GetFontMetrics(out var fm); float textHeight = fm.Descent - fm.Ascent;
             for (int i = 0; i < lines.Length; i++)
             {
                 float tx = bx + pad;
                 if (showSwatches && i > 0 && i - 1 < tooltipSeries.Count)
                 {
-                    var sv = tooltipSeries[i - 1];
-                    var col = model.Theme.PrimarySeriesColor;
+                    var sv = tooltipSeries[i - 1]; var col = model.Theme.PrimarySeriesColor;
                     if (palette != null && sv.PaletteIndex.HasValue && sv.PaletteIndex.Value >= 0 && sv.PaletteIndex.Value < palette.Count)
-                    {
-                        col = palette[sv.PaletteIndex.Value];
-                    }
+                    { col = palette[sv.PaletteIndex.Value]; }
                     using var sw = new SKPaint { Color = new SKColor(col.R, col.G, col.B, col.A), Style = SKPaintStyle.Fill, IsAntialias = true };
-                    float topText = ty + fm.Ascent;
-                    float verticalPadding = (textHeight - swatchSize) * 0.5f;
-                    float swTop = topText + verticalPadding;
-                    var swRect = new SKRect(tx, swTop, tx + swatchSize, swTop + swatchSize);
-                    ctx.Canvas.DrawRect(swRect, sw);
-                    tx += swatchSize + swatchGap;
+                    float topText = ty + fm.Ascent; float verticalPadding = (textHeight - swatchSize) * 0.5f; float swTop = topText + verticalPadding; var swRect = new SKRect(tx, swTop, tx + swatchSize, swTop + swatchSize); ctx.Canvas.DrawRect(swRect, sw); tx += swatchSize + swatchGap;
                 }
-                ctx.Canvas.DrawText(lines[i], tx, ty, tipTx);
-                ty += lineH;
+                ctx.Canvas.DrawText(lines[i], tx, ty, tipTx); ty += lineH;
             }
         }
 
         internal static FastCharts.Core.Primitives.ColorRgba ResolveSeriesColorStatic(ChartModel model, object seriesRef, System.Collections.Generic.IReadOnlyList<FastCharts.Core.Primitives.ColorRgba> palette)
         {
             var primary = model.Theme.PrimarySeriesColor;
-            if (palette == null || palette.Count == 0)
-            {
-                return primary;
-            }
+            if (palette == null || palette.Count == 0) return primary;
             if (seriesRef is BandSeries band)
             {
                 int idx = model.Series.OfType<BandSeries>().ToList().IndexOf(band);

--- a/tests/FastCharts.Core.Tests/ExportPngTests.cs
+++ b/tests/FastCharts.Core.Tests/ExportPngTests.cs
@@ -1,0 +1,35 @@
+using System.IO;
+using FastCharts.Core;
+using FastCharts.Core.Primitives;
+using FastCharts.Core.Series;
+using FastCharts.Rendering.Skia;
+using Xunit;
+
+namespace FastCharts.Core.Tests
+{
+    public class ExportPngTests
+    {
+        [Fact]
+        public void ExportPngWritesNonEmptyPngStream()
+        {
+            var model = new ChartModel();
+            model.AddSeries(new LineSeries(new[]
+            {
+                new PointD(0,0), new PointD(1,1), new PointD(2,4), new PointD(3,9)
+            }) { Title = "Parabola" });
+            model.UpdateScales(400, 300);
+            var r = new SkiaChartRenderer();
+            using var ms = new MemoryStream();
+            r.ExportPng(model, ms, 400, 300);
+            Assert.True(ms.Length > 100, $"PNG length too small: {ms.Length}");
+            ms.Position = 0;
+            var sig = new byte[8];
+            int read = ms.Read(sig, 0, 8);
+            Assert.Equal(8, read);
+            Assert.Equal(0x89, sig[0]);
+            Assert.Equal((byte)'P', sig[1]);
+            Assert.Equal((byte)'N', sig[2]);
+            Assert.Equal((byte)'G', sig[3]);
+        }
+    }
+}

--- a/tests/FastCharts.Core.Tests/FastCharts.Core.Tests.csproj
+++ b/tests/FastCharts.Core.Tests/FastCharts.Core.Tests.csproj
@@ -19,5 +19,6 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\FastCharts.Core\FastCharts.Core.csproj" />
+        <ProjectReference Include="..\..\src\FastCharts.Rendering.Skia\FastCharts.Rendering.Skia.csproj" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Résumé:
•	SkiaChartRenderer: nouvelles méthodes RenderToBitmap() et ExportPng().
•	Paramètres: taille (px), transparence optionnelle, qualité (placeholder pour futurs formats).
•	Test ExportPngWritesNonEmptyPngStream: vérifie signature PNG et taille minimale.
•	Ajout référence FastCharts.Rendering.Skia dans tests Core.
•	Aucune régression build (warnings en erreurs).

Limitations:
•	Uniquement PNG (pas encore JPEG/WebP).
•	Pas d’overload file path direct (stream uniquement).
•	Pas d’API WPF conviviale (ex: FastChart.SavePng).