### PR TITLE
v1.3 "Finance": candlestick volume & colors, SMA/EMA/Bollinger indicators, linked charts, browser-triggered release

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -4,11 +4,20 @@ on:
   push:
     tags:
       - 'v*'  # Triggers on version tags like v1.0.0, v1.2.3, etc.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release, e.g. 1.3.0 (tag v1.3.0 is created automatically)'
+        required: true
+        type: string
 
 jobs:
   publish:
     runs-on: windows-latest
-    
+
+    permissions:
+      contents: write # push release tag + create GitHub release
+
     environment: nuget-production # Optional: use GitHub environment for secrets management
     
     steps:
@@ -24,13 +33,26 @@ jobs:
             8.0.x
             6.0.x
 
-      - name: Extract version from tag
+      - name: Extract version from tag or input
         id: get-version
         run: |
-          $tag = "${{ github.ref }}"
-          $version = $tag -replace '^refs/tags/v', ''
+          if ("${{ github.event_name }}" -eq "workflow_dispatch") {
+            $version = "${{ github.event.inputs.version }}" -replace '^v', ''
+          } else {
+            $tag = "${{ github.ref }}"
+            $version = $tag -replace '^refs/tags/v', ''
+          }
           echo "VERSION=$version" >> $env:GITHUB_OUTPUT
           echo "Extracted version: $version"
+
+      - name: Create tag (browser-triggered release)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          $version = "${{ steps.get-version.outputs.VERSION }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v$version" -m "FastCharts v$version"
+          git push origin "v$version"
 
       - name: Restore dependencies
         run: dotnet restore FastChartsSolution.sln
@@ -90,7 +112,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
+          tag_name: v${{ steps.get-version.outputs.VERSION }}
           release_name: FastCharts ${{ steps.get-version.outputs.VERSION }}
           draft: false
           prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to FastCharts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-07-05
+
+### ✨ **Added — "Finance"**
+
+- **Enhanced candlesticks** (P2-SERIES-CANDLESTICK): `OhlcSeries.BullColor`/`BearColor` (null = theme-derived, unchanged default), optional `OhlcPoint.Volume` and `ShowVolume` rendering volume bars in a bottom band of the plot (`VolumePaneRatio`, `VolumeOpacity`) colored bull/bear — the classic trading layout.
+- **Financial indicators** (P3-FIN-INDICATORS, first batch): `Indicators.Sma`, `Indicators.Ema` (SMA-seeded), `Indicators.BollingerBands` (middle `LineSeries` + ±kσ `BandSeries`). All return ready-to-add series and accept either `IReadOnlyList<PointD>` or an `OhlcSeries` (Close prices). O(n) sliding-window SMA/EMA.
+- **Linked charts** (P2-AX-LINK): `ChartLinkGroup` synchronizes the visible X range across models (price chart + indicator chart stay aligned under zoom/pan); survives axis replacement (e.g. switching to log X); `Remove`/`Dispose` unlink cleanly.
+- **`AxisBase.VisibleRangeChanged` event**: raised on any visible-range change (zoom, pan, auto-fit) — the hook behind axis linking, also usable by apps.
+- **Release from the browser**: the *Publish NuGet Packages* workflow now supports manual dispatch (Actions → Run workflow → enter version) — it creates the tag, builds, tests, publishes to NuGet and creates the GitHub release. No local git needed.
+
 ## [1.2.0] - 2026-07-05
 
 ### ✨ **Added — "Everyday chart"**

--- a/README.md
+++ b/README.md
@@ -176,6 +176,26 @@ model.AddSeries(series);          // renders like any other series
 readings.Add(new SensorReading()); // chart updates automatically
 ```
 
+### Finance: Candlesticks, Volume & Indicators
+```csharp
+var candles = new OhlcSeries(ohlcPoints)   // OhlcPoint(x, o, h, l, c, volume)
+{
+    ShowVolume = true,                      // volume bars at the bottom
+    BullColor = new ColorRgba(0, 200, 80),
+    BearColor = new ColorRgba(220, 40, 40)
+};
+model.AddSeries(candles);
+model.AddSeries(Indicators.Sma(candles, 20));       // moving average overlay
+var bb = Indicators.BollingerBands(candles, 20, 2);
+model.AddSeries(bb.Band);                            // ±2σ envelope
+model.AddSeries(bb.Middle);
+
+// Keep a price chart and an indicator chart zoom-synced
+var link = new ChartLinkGroup();
+link.Add(priceModel);
+link.Add(indicatorModel);
+```
+
 ### Interactive Behaviors
 ```csharp
 model.AddBehavior(new PanBehavior());

--- a/RoadMap.md
+++ b/RoadMap.md
@@ -176,17 +176,18 @@ Guiding rule: each release is small, shippable, and keeps the KISS promise
 (a beautiful curve from a `Dictionary<double, double>` with zero decisions).
 Long-term target: feature parity with premium WPF charting (SciChart).
 
-### v1.2 — "Everyday chart"
-- Markers on LineSeries (render ShowMarkers/MarkerSize/MarkerShape)
-- Spline smoothing (P2-SERIES-SPLINE) via `LineSeries.Smoothing`
-- SVG export (P2-EXPORT-SVG) through SKSvgCanvas
-- Dynamic themes (P2-THEME-DYNAMIC): `Themes.Light/Dark/HighContrast`, custom palettes
-- KISS: `model.AddSeries(data, ChartKind.Area|Scatter|Bar|StepLine)`
+### v1.2 — "Everyday chart" ✅ SHIPPED
+- [x] Markers on LineSeries (render ShowMarkers/MarkerSize/MarkerShape)
+- [x] Spline smoothing (P2-SERIES-SPLINE) via `LineSeries.Smoothing`
+- [x] SVG export (P2-EXPORT-SVG) through SKSvgCanvas
+- [x] Dynamic themes (P2-THEME-DYNAMIC): `ChartThemes.Light/Dark/HighContrast`, custom palettes
+- [x] KISS: `model.AddSeries(data, ChartKind.Area|Scatter|Bar|StepLine)`
 
-### v1.3 — "Finance"
-- Enhanced candlestick + volume (P2-SERIES-CANDLESTICK)
-- Indicators: SMA, EMA, Bollinger first; RSI/MACD next (P3-FIN-INDICATORS)
-- Linked axes across charts (P2-AX-LINK) — price + indicator sync pattern
+### v1.3 — "Finance" ✅ SHIPPED
+- [x] Enhanced candlestick + volume (P2-SERIES-CANDLESTICK)
+- [x] Indicators: SMA, EMA, Bollinger (P3-FIN-INDICATORS — RSI/MACD remain for later)
+- [x] Linked axes across charts (P2-AX-LINK) — ChartLinkGroup
+- [x] Browser-triggered release workflow (workflow_dispatch)
 
 ### v1.4 — "Large volumes & GPU"
 - BenchmarkDotNet suite first (T-PERF-PROF)

--- a/src/FastCharts.Core/Axes/AxisBase.cs
+++ b/src/FastCharts.Core/Axes/AxisBase.cs
@@ -1,21 +1,54 @@
-using FastCharts.Core.Abstractions;
+using System;
+
 using FastCharts.Core.Primitives;
+using FastCharts.Core.Utilities;
 
 namespace FastCharts.Core.Axes;
 
 public abstract class AxisBase
 {
+    private FRange _visibleRange;
+
     public FRange DataRange { get; set; }
-    public FRange VisibleRange { get; set; }
+
+    /// <summary>
+    /// Currently visible range. Raises <see cref="VisibleRangeChanged"/> when it actually
+    /// changes, which enables cross-chart axis linking (see ChartLinkGroup).
+    /// </summary>
+    public FRange VisibleRange
+    {
+        get => _visibleRange;
+        set
+        {
+            if (DoubleUtils.AreEqual(value.Min, _visibleRange.Min) && DoubleUtils.AreEqual(value.Max, _visibleRange.Max))
+            {
+                return;
+            }
+
+            _visibleRange = value;
+            VisibleRangeChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    /// <summary>
+    /// Raised after <see cref="VisibleRange"/> changes (zoom, pan, auto-fit, linked axes).
+    /// </summary>
+    public event EventHandler? VisibleRangeChanged;
+
     public string? LabelFormat { get; set; }
+
     public bool ShowMinorTicks { get; set; } = true;
+
     public bool ShowMinorGrid { get; set; } = true;
+
     public double MinorGridOpacity { get; set; } = 0.4;
+
     protected AxisBase()
     {
         DataRange = new FRange(0, 1);
-        VisibleRange = new FRange(0, 1);
+        _visibleRange = new FRange(0, 1);
         LabelFormat = "G";
     }
+
     public abstract void UpdateScale(double pixelMin, double pixelMax);
 }

--- a/src/FastCharts.Core/FastCharts.Core.csproj
+++ b/src/FastCharts.Core/FastCharts.Core.csproj
@@ -14,7 +14,7 @@
     <!-- NuGet Package Metadata -->
     <PackageId>FastCharts.Core</PackageId>
     <Title>FastCharts Core Library</Title>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <Authors>FastCharts Team</Authors>
     <Company>FastCharts</Company>
     <Product>FastCharts</Product>
@@ -33,13 +33,14 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     
     <!-- Release Notes -->
-    <PackageReleaseNotes>FastCharts v1.2.0 — "Everyday chart"
+    <PackageReleaseNotes>FastCharts v1.3.0 — "Finance"
 
-- Markers on LineSeries (ShowMarkers, MarkerSize, MarkerShape incl. Diamond/Cross/Plus)
-- Spline smoothing: series.Smoothing = LineSmoothing.Spline
-- SVG vector export: SkiaChartRenderer.ExportSvg / ChartExportService.ExportToSvgFile
-- Dynamic themes: ChartThemes.Light/Dark/HighContrast + CustomTheme palettes
-- KISS: model.AddSeries(data, ChartKind.Area|Scatter|Bar|StepLine)
+- Enhanced candlesticks: BullColor/BearColor, per-point Volume with bottom volume band
+- Indicators: Indicators.Sma / Ema / BollingerBands producing ready-to-add series
+  (PointD lists or OhlcSeries Close prices)
+- Cross-chart X axis sync: ChartLinkGroup (price + indicator layout)
+- AxisBase.VisibleRangeChanged event
+- Release from browser: run the 'Publish NuGet Packages' workflow manually with a version
 
 See CHANGELOG.md for details.</PackageReleaseNotes>
   </PropertyGroup>

--- a/src/FastCharts.Core/Finance/BollingerBandsResult.cs
+++ b/src/FastCharts.Core/Finance/BollingerBandsResult.cs
@@ -1,0 +1,27 @@
+using FastCharts.Core.Series;
+
+namespace FastCharts.Core.Finance
+{
+    /// <summary>
+    /// Output of <see cref="Indicators.BollingerBands(System.Collections.Generic.IReadOnlyList{FastCharts.Core.Primitives.PointD}, int, double)"/>:
+    /// the middle moving average and the ±kσ envelope band.
+    /// </summary>
+    public sealed class BollingerBandsResult
+    {
+        public BollingerBandsResult(LineSeries middle, BandSeries band)
+        {
+            Middle = middle;
+            Band = band;
+        }
+
+        /// <summary>
+        /// Middle line (simple moving average)
+        /// </summary>
+        public LineSeries Middle { get; }
+
+        /// <summary>
+        /// Envelope band between -kσ and +kσ
+        /// </summary>
+        public BandSeries Band { get; }
+    }
+}

--- a/src/FastCharts.Core/Finance/Indicators.cs
+++ b/src/FastCharts.Core/Finance/Indicators.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+
+using FastCharts.Core.Primitives;
+using FastCharts.Core.Series;
+
+namespace FastCharts.Core.Finance
+{
+    /// <summary>
+    /// Financial indicators producing ready-to-add chart series (P3-FIN-INDICATORS).
+    /// KISS: <c>model.AddSeries(Indicators.Sma(prices, 20));</c>
+    /// All overloads accepting <see cref="OhlcSeries"/> use the Close price.
+    /// </summary>
+    public static class Indicators
+    {
+        /// <summary>
+        /// Simple Moving Average. The output starts at the first index where a full
+        /// window is available (period - 1), so no partial averages are emitted.
+        /// </summary>
+        /// <param name="source">Input points (sorted by X)</param>
+        /// <param name="period">Window size (≥ 1)</param>
+        /// <param name="title">Optional title (default "SMA {period}")</param>
+        /// <returns>Line series of the moving average</returns>
+        public static LineSeries Sma(IReadOnlyList<PointD> source, int period, string? title = null)
+        {
+            ValidateInput(source, period);
+
+            var result = new List<PointD>(Math.Max(0, source.Count - period + 1));
+            var sum = 0.0;
+
+            for (var i = 0; i < source.Count; i++)
+            {
+                sum += source[i].Y;
+
+                if (i >= period)
+                {
+                    sum -= source[i - period].Y;
+                }
+
+                if (i >= period - 1)
+                {
+                    result.Add(new PointD(source[i].X, sum / period));
+                }
+            }
+
+            return new LineSeries(result) { Title = title ?? $"SMA {period}" };
+        }
+
+        /// <summary>
+        /// Simple Moving Average over an OHLC series' Close prices
+        /// </summary>
+        public static LineSeries Sma(OhlcSeries source, int period, string? title = null)
+        {
+            return Sma(ToClosePoints(source), period, title);
+        }
+
+        /// <summary>
+        /// Exponential Moving Average (smoothing factor 2 / (period + 1)),
+        /// seeded with the SMA of the first window.
+        /// </summary>
+        /// <param name="source">Input points (sorted by X)</param>
+        /// <param name="period">Window size (≥ 1)</param>
+        /// <param name="title">Optional title (default "EMA {period}")</param>
+        /// <returns>Line series of the exponential moving average</returns>
+        public static LineSeries Ema(IReadOnlyList<PointD> source, int period, string? title = null)
+        {
+            ValidateInput(source, period);
+
+            var result = new List<PointD>(Math.Max(0, source.Count - period + 1));
+
+            if (source.Count >= period)
+            {
+                // Seed: SMA of the first window
+                var seed = 0.0;
+                for (var i = 0; i < period; i++)
+                {
+                    seed += source[i].Y;
+                }
+
+                seed /= period;
+                result.Add(new PointD(source[period - 1].X, seed));
+
+                var alpha = 2.0 / (period + 1);
+                var ema = seed;
+
+                for (var i = period; i < source.Count; i++)
+                {
+                    ema = ((source[i].Y - ema) * alpha) + ema;
+                    result.Add(new PointD(source[i].X, ema));
+                }
+            }
+
+            return new LineSeries(result) { Title = title ?? $"EMA {period}" };
+        }
+
+        /// <summary>
+        /// Exponential Moving Average over an OHLC series' Close prices
+        /// </summary>
+        public static LineSeries Ema(OhlcSeries source, int period, string? title = null)
+        {
+            return Ema(ToClosePoints(source), period, title);
+        }
+
+        /// <summary>
+        /// Bollinger Bands: middle SMA plus a band at ±k standard deviations.
+        /// Add both parts to the chart:
+        /// <code>
+        /// var bb = Indicators.BollingerBands(prices, 20, 2);
+        /// model.AddSeries(bb.Band);
+        /// model.AddSeries(bb.Middle);
+        /// </code>
+        /// </summary>
+        /// <param name="source">Input points (sorted by X)</param>
+        /// <param name="period">Window size (default 20)</param>
+        /// <param name="k">Standard deviation multiplier (default 2)</param>
+        /// <returns>Middle line series + envelope band series</returns>
+        public static BollingerBandsResult BollingerBands(IReadOnlyList<PointD> source, int period = 20, double k = 2.0)
+        {
+            ValidateInput(source, period);
+
+            var middle = new List<PointD>(Math.Max(0, source.Count - period + 1));
+            var band = new List<BandPoint>(Math.Max(0, source.Count - period + 1));
+
+            for (var i = period - 1; i < source.Count; i++)
+            {
+                var mean = 0.0;
+                for (var j = i - period + 1; j <= i; j++)
+                {
+                    mean += source[j].Y;
+                }
+
+                mean /= period;
+
+                var variance = 0.0;
+                for (var j = i - period + 1; j <= i; j++)
+                {
+                    var d = source[j].Y - mean;
+                    variance += d * d;
+                }
+
+                var sigma = Math.Sqrt(variance / period);
+
+                middle.Add(new PointD(source[i].X, mean));
+                band.Add(new BandPoint(source[i].X, mean - (k * sigma), mean + (k * sigma)));
+            }
+
+            return new BollingerBandsResult(
+                new LineSeries(middle) { Title = $"BB {period} middle" },
+                new BandSeries(band) { Title = $"BB {period} ±{k}σ" });
+        }
+
+        /// <summary>
+        /// Bollinger Bands over an OHLC series' Close prices
+        /// </summary>
+        public static BollingerBandsResult BollingerBands(OhlcSeries source, int period = 20, double k = 2.0)
+        {
+            return BollingerBands(ToClosePoints(source), period, k);
+        }
+
+        private static IReadOnlyList<PointD> ToClosePoints(OhlcSeries source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            var points = new List<PointD>(source.Data.Count);
+            for (var i = 0; i < source.Data.Count; i++)
+            {
+                points.Add(new PointD(source.Data[i].X, source.Data[i].Close));
+            }
+
+            return points;
+        }
+
+        private static void ValidateInput(IReadOnlyList<PointD> source, int period)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (period < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(period), period, "Period must be at least 1");
+            }
+        }
+    }
+}

--- a/src/FastCharts.Core/Interactivity/ChartLinkGroup.cs
+++ b/src/FastCharts.Core/Interactivity/ChartLinkGroup.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+using FastCharts.Core.Axes;
+using FastCharts.Core.Primitives;
+
+namespace FastCharts.Core.Interactivity
+{
+    /// <summary>
+    /// Synchronizes the visible X range across several charts (P2-AX-LINK).
+    /// The classic finance layout — price chart on top, indicator chart below —
+    /// stays aligned under zoom and pan:
+    /// <code>
+    /// var link = new ChartLinkGroup();
+    /// link.Add(priceModel);
+    /// link.Add(indicatorModel);
+    /// </code>
+    /// Dispose the group (or Remove a model) to stop synchronizing.
+    /// </summary>
+    public sealed class ChartLinkGroup : IDisposable
+    {
+        private readonly List<Entry> _entries = new List<Entry>();
+        private bool _updating;
+        private bool _disposed;
+
+        /// <summary>
+        /// Number of linked charts
+        /// </summary>
+        public int Count => _entries.Count;
+
+        /// <summary>
+        /// Adds a chart to the group. Its X axis immediately adopts the group's
+        /// current visible range (from the first chart added, if any).
+        /// </summary>
+        /// <param name="model">Chart model to link</param>
+        public void Add(ChartModel model)
+        {
+            if (model == null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(ChartLinkGroup));
+            }
+
+            for (var i = 0; i < _entries.Count; i++)
+            {
+                if (ReferenceEquals(_entries[i].Model, model))
+                {
+                    return; // Already linked
+                }
+            }
+
+            var entry = new Entry(this, model);
+            _entries.Add(entry);
+
+            // Align the newcomer with the group's current range
+            if (_entries.Count > 1)
+            {
+                Propagate(_entries[0].Model, _entries[0].CurrentAxis.VisibleRange);
+            }
+        }
+
+        /// <summary>
+        /// Removes a chart from the group and stops synchronizing it.
+        /// </summary>
+        /// <param name="model">Chart model to unlink</param>
+        /// <returns>True when the chart was part of the group</returns>
+        public bool Remove(ChartModel model)
+        {
+            for (var i = 0; i < _entries.Count; i++)
+            {
+                if (ReferenceEquals(_entries[i].Model, model))
+                {
+                    _entries[i].Dispose();
+                    _entries.RemoveAt(i);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private void OnAxisRangeChanged(ChartModel source, AxisBase axis)
+        {
+            if (_updating)
+            {
+                return;
+            }
+
+            Propagate(source, axis.VisibleRange);
+        }
+
+        private void Propagate(ChartModel source, FRange range)
+        {
+            _updating = true;
+            try
+            {
+                for (var i = 0; i < _entries.Count; i++)
+                {
+                    if (!ReferenceEquals(_entries[i].Model, source))
+                    {
+                        _entries[i].CurrentAxis.VisibleRange = range;
+                    }
+                }
+            }
+            finally
+            {
+                _updating = false;
+            }
+        }
+
+        /// <summary>
+        /// Unlinks all charts
+        /// </summary>
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            for (var i = 0; i < _entries.Count; i++)
+            {
+                _entries[i].Dispose();
+            }
+
+            _entries.Clear();
+        }
+
+        /// <summary>
+        /// Tracks one linked chart: follows its current X axis, including axis replacement
+        /// (e.g. switching to a logarithmic axis re-hooks the subscription automatically).
+        /// </summary>
+        private sealed class Entry : IDisposable
+        {
+            private readonly ChartLinkGroup _group;
+
+            public Entry(ChartLinkGroup group, ChartModel model)
+            {
+                _group = group;
+                Model = model;
+                CurrentAxis = (AxisBase)model.XAxis;
+                CurrentAxis.VisibleRangeChanged += OnRangeChanged;
+                Model.PropertyChanged += OnModelPropertyChanged;
+            }
+
+            public ChartModel Model { get; }
+
+            public AxisBase CurrentAxis { get; private set; }
+
+            private void OnRangeChanged(object? sender, EventArgs e)
+            {
+                _group.OnAxisRangeChanged(Model, CurrentAxis);
+            }
+
+            private void OnModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+            {
+                if (e.PropertyName != nameof(ChartModel.XAxis))
+                {
+                    return;
+                }
+
+                // X axis instance was replaced: move the subscription
+                CurrentAxis.VisibleRangeChanged -= OnRangeChanged;
+                CurrentAxis = (AxisBase)Model.XAxis;
+                CurrentAxis.VisibleRangeChanged += OnRangeChanged;
+            }
+
+            public void Dispose()
+            {
+                CurrentAxis.VisibleRangeChanged -= OnRangeChanged;
+                Model.PropertyChanged -= OnModelPropertyChanged;
+            }
+        }
+    }
+}

--- a/src/FastCharts.Core/Series/OhlcPoint.cs
+++ b/src/FastCharts.Core/Series/OhlcPoint.cs
@@ -8,6 +8,11 @@ public struct OhlcPoint
     public double Low { get; set; }
     public double Close { get; set; }
 
+    /// <summary>
+    /// Optional traded volume for this period (rendered when OhlcSeries.ShowVolume is true).
+    /// </summary>
+    public double? Volume { get; set; }
+
     public OhlcPoint(double x, double open, double high, double low, double close)
     {
         X = x;
@@ -15,5 +20,16 @@ public struct OhlcPoint
         High = high;
         Low = low;
         Close = close;
+        Volume = null;
+    }
+
+    public OhlcPoint(double x, double open, double high, double low, double close, double volume)
+    {
+        X = x;
+        Open = open;
+        High = high;
+        Low = low;
+        Close = close;
+        Volume = volume;
     }
 }

--- a/src/FastCharts.Core/Series/OhlcSeries.cs
+++ b/src/FastCharts.Core/Series/OhlcSeries.cs
@@ -10,6 +10,32 @@ public sealed class OhlcSeries : SeriesBase, ISeriesRangeProvider
 {
     public IList<OhlcPoint> Data { get; }
     public double? Width { get; set; }
+
+    /// <summary>
+    /// Body/wick color for rising candles (Close >= Open). Null = theme default.
+    /// </summary>
+    public ColorRgba? BullColor { get; set; }
+
+    /// <summary>
+    /// Body/wick color for falling candles (Close &lt; Open). Null = theme default.
+    /// </summary>
+    public ColorRgba? BearColor { get; set; }
+
+    /// <summary>
+    /// When true, volume bars are drawn in a band at the bottom of the plot
+    /// (classic trading layout) using each point's Volume value.
+    /// </summary>
+    public bool ShowVolume { get; set; }
+
+    /// <summary>
+    /// Fraction of the plot height reserved for volume bars (0.05 to 0.5, default 0.2).
+    /// </summary>
+    public double VolumePaneRatio { get; set; } = 0.2;
+
+    /// <summary>
+    /// Opacity of volume bars [0..1] (default 0.35).
+    /// </summary>
+    public double VolumeOpacity { get; set; } = 0.35;
     public double WickThickness { get; set; } = 1.0;
     public double UpFillOpacity { get; set; } = 0.9;
     public double DownFillOpacity { get; set; } = 0.4;

--- a/src/FastCharts.Rendering.Skia/FastCharts.Rendering.Skia.csproj
+++ b/src/FastCharts.Rendering.Skia/FastCharts.Rendering.Skia.csproj
@@ -13,7 +13,7 @@
         <!-- NuGet Package Metadata -->
         <PackageId>FastCharts.Rendering.Skia</PackageId>
         <Title>FastCharts Skia Rendering Engine</Title>
-        <Version>1.2.0</Version>
+        <Version>1.3.0</Version>
         <Authors>FastCharts Team</Authors>
         <Company>FastCharts</Company>
         <Product>FastCharts</Product>
@@ -31,13 +31,14 @@
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         
-        <PackageReleaseNotes>FastCharts v1.2.0 — "Everyday chart"
+        <PackageReleaseNotes>FastCharts v1.3.0 — "Finance"
 
-- Markers on LineSeries (ShowMarkers, MarkerSize, MarkerShape incl. Diamond/Cross/Plus)
-- Spline smoothing: series.Smoothing = LineSmoothing.Spline
-- SVG vector export: SkiaChartRenderer.ExportSvg / ChartExportService.ExportToSvgFile
-- Dynamic themes: ChartThemes.Light/Dark/HighContrast + CustomTheme palettes
-- KISS: model.AddSeries(data, ChartKind.Area|Scatter|Bar|StepLine)
+- Enhanced candlesticks: BullColor/BearColor, per-point Volume with bottom volume band
+- Indicators: Indicators.Sma / Ema / BollingerBands producing ready-to-add series
+  (PointD lists or OhlcSeries Close prices)
+- Cross-chart X axis sync: ChartLinkGroup (price + indicator layout)
+- AxisBase.VisibleRangeChanged event
+- Release from browser: run the 'Publish NuGet Packages' workflow manually with a version
 
 See CHANGELOG.md for details.</PackageReleaseNotes>
     </PropertyGroup>

--- a/src/FastCharts.Rendering.Skia/Rendering/Layers/OhlcLayer.cs
+++ b/src/FastCharts.Rendering.Skia/Rendering/Layers/OhlcLayer.cs
@@ -17,13 +17,18 @@ internal sealed class OhlcLayer : ISeriesSubLayer
             {
                 continue;
             }
-            var cUp = model.Theme.PrimarySeriesColor;
-            var cDown = (paletteCount > 1 && palette != null)
+            var cUp = os.BullColor ?? model.Theme.PrimarySeriesColor;
+            var cDown = os.BearColor ?? ((paletteCount > 1 && palette != null)
                 ? palette[1]
-                : new FastCharts.Core.Primitives.ColorRgba((byte)(cUp.R * 0.7), (byte)(cUp.G * 0.3), (byte)(cUp.B * 0.3), cUp.A);
+                : new FastCharts.Core.Primitives.ColorRgba((byte)(cUp.R * 0.7), (byte)(cUp.G * 0.3), (byte)(cUp.B * 0.3), cUp.A));
             var wickStroke = (float)System.Math.Max(1.0, os.WickThickness);
             ctx.Canvas.Save();
             ctx.Canvas.ClipRect(pr);
+
+            if (os.ShowVolume)
+            {
+                RenderVolume(ctx, os, cUp, cDown);
+            }
             for (var i = 0; i < os.Data.Count; i++)
             {
                 var p = os.Data[i];
@@ -54,6 +59,66 @@ internal sealed class OhlcLayer : ISeriesSubLayer
                 ctx.Canvas.DrawRect(rect, bodyStroke);
             }
             ctx.Canvas.Restore();
+        }
+    }
+
+    /// <summary>
+    /// Draws volume bars in a band at the bottom of the plot (classic trading layout).
+    /// Bars are scaled to the maximum volume of the series and colored bull/bear.
+    /// </summary>
+    private static void RenderVolume(RenderContext ctx, OhlcSeries os, FastCharts.Core.Primitives.ColorRgba cUp, FastCharts.Core.Primitives.ColorRgba cDown)
+    {
+        var model = ctx.Model;
+        var pr = ctx.PlotRect;
+
+        var maxVolume = 0.0;
+        for (var i = 0; i < os.Data.Count; i++)
+        {
+            var v = os.Data[i].Volume;
+            if (v.HasValue && v.Value > maxVolume)
+            {
+                maxVolume = v.Value;
+            }
+        }
+
+        if (maxVolume <= 0)
+        {
+            return;
+        }
+
+        var ratio = RenderMath.Clamp01(os.VolumePaneRatio);
+        if (ratio < 0.05)
+        {
+            ratio = 0.05;
+        }
+        if (ratio > 0.5)
+        {
+            ratio = 0.5;
+        }
+
+        var paneHeight = pr.Height * (float)ratio;
+        var baseline = pr.Bottom;
+        var alpha = (byte)(RenderMath.Clamp01(os.VolumeOpacity) * 255);
+
+        using var upPaint = new SKPaint { IsAntialias = false, Style = SKPaintStyle.Fill, Color = new SKColor(cUp.R, cUp.G, cUp.B, alpha) };
+        using var downPaint = new SKPaint { IsAntialias = false, Style = SKPaintStyle.Fill, Color = new SKColor(cDown.R, cDown.G, cDown.B, alpha) };
+
+        for (var i = 0; i < os.Data.Count; i++)
+        {
+            var p = os.Data[i];
+            if (!p.Volume.HasValue || p.Volume.Value <= 0)
+            {
+                continue;
+            }
+
+            var w = os.GetWidthFor(i);
+            var half = w * 0.5;
+            var xL = PixelMapper.X(p.X - half * 0.7, model.XAxis, pr);
+            var xR = PixelMapper.X(p.X + half * 0.7, model.XAxis, pr);
+            var h = (float)(p.Volume.Value / maxVolume) * paneHeight;
+
+            var rect = SKRect.Create(xL, baseline - h, xR - xL, h);
+            ctx.Canvas.DrawRect(rect, p.Close >= p.Open ? upPaint : downPaint);
         }
     }
 }

--- a/src/FastCharts.Wpf/FastCharts.Wpf.csproj
+++ b/src/FastCharts.Wpf/FastCharts.Wpf.csproj
@@ -15,7 +15,7 @@
         <!-- NuGet Package Metadata -->
         <PackageId>FastCharts.Wpf</PackageId>
         <Title>FastCharts WPF Controls</Title>
-        <Version>1.2.0</Version>
+        <Version>1.3.0</Version>
         <Authors>FastCharts Team</Authors>
         <Company>FastCharts</Company>
         <Product>FastCharts</Product>
@@ -33,13 +33,14 @@
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         
-        <PackageReleaseNotes>FastCharts v1.2.0 — "Everyday chart"
+        <PackageReleaseNotes>FastCharts v1.3.0 — "Finance"
 
-- Markers on LineSeries (ShowMarkers, MarkerSize, MarkerShape incl. Diamond/Cross/Plus)
-- Spline smoothing: series.Smoothing = LineSmoothing.Spline
-- SVG vector export: SkiaChartRenderer.ExportSvg / ChartExportService.ExportToSvgFile
-- Dynamic themes: ChartThemes.Light/Dark/HighContrast + CustomTheme palettes
-- KISS: model.AddSeries(data, ChartKind.Area|Scatter|Bar|StepLine)
+- Enhanced candlesticks: BullColor/BearColor, per-point Volume with bottom volume band
+- Indicators: Indicators.Sma / Ema / BollingerBands producing ready-to-add series
+  (PointD lists or OhlcSeries Close prices)
+- Cross-chart X axis sync: ChartLinkGroup (price + indicator layout)
+- AxisBase.VisibleRangeChanged event
+- Release from browser: run the 'Publish NuGet Packages' workflow manually with a version
 
 See CHANGELOG.md for details.</PackageReleaseNotes>
     </PropertyGroup>

--- a/tests/FastCharts.Core.Tests/Finance/IndicatorsTests.cs
+++ b/tests/FastCharts.Core.Tests/Finance/IndicatorsTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastCharts.Core.Finance;
+using FastCharts.Core.Primitives;
+using FastCharts.Core.Series;
+using FluentAssertions;
+using Xunit;
+
+namespace FastCharts.Core.Tests.Finance
+{
+    /// <summary>
+    /// Tests for financial indicators (v1.3): SMA, EMA, Bollinger Bands
+    /// </summary>
+    public class IndicatorsTests
+    {
+        private static IReadOnlyList<PointD> Constant(double value, int count)
+        {
+            return Enumerable.Range(0, count).Select(i => new PointD(i, value)).ToList();
+        }
+
+        [Fact]
+        public void Sma_ConstantInput_ReturnsConstantOutput()
+        {
+            var sma = Indicators.Sma(Constant(42, 10), 3);
+
+            sma.Data.Should().HaveCount(8); // 10 - 3 + 1
+            sma.Data.Should().OnlyContain(p => Math.Abs(p.Y - 42) < 1e-9);
+            sma.Title.Should().Be("SMA 3");
+        }
+
+        [Fact]
+        public void Sma_KnownValues_AreCorrect()
+        {
+            var source = new[] { 1.0, 2.0, 3.0, 4.0, 5.0 }
+                .Select((v, i) => new PointD(i, v)).ToList();
+
+            var sma = Indicators.Sma(source, 3);
+
+            // Windows: (1+2+3)/3=2, (2+3+4)/3=3, (3+4+5)/3=4
+            sma.Data.Select(p => p.Y).Should().ContainInOrder(2.0, 3.0, 4.0);
+            sma.Data[0].X.Should().Be(2); // aligned on last point of window
+        }
+
+        [Fact]
+        public void Ema_KnownValues_AreCorrect()
+        {
+            var source = new[] { 2.0, 4.0, 6.0, 8.0 }
+                .Select((v, i) => new PointD(i, v)).ToList();
+
+            var ema = Indicators.Ema(source, 2);
+
+            // Seed = SMA(2,4) = 3 ; alpha = 2/3
+            // ema(6) = (6-3)*2/3 + 3 = 5 ; ema(8) = (8-5)*2/3 + 5 = 7
+            ema.Data.Should().HaveCount(3);
+            ema.Data[0].Y.Should().BeApproximately(3.0, 1e-9);
+            ema.Data[1].Y.Should().BeApproximately(5.0, 1e-9);
+            ema.Data[2].Y.Should().BeApproximately(7.0, 1e-9);
+        }
+
+        [Fact]
+        public void Ema_ShorterThanPeriod_ReturnsEmptySeries()
+        {
+            var ema = Indicators.Ema(Constant(1, 3), 5);
+
+            ema.IsEmpty.Should().BeTrue();
+        }
+
+        [Fact]
+        public void BollingerBands_ConstantInput_CollapsesToMiddle()
+        {
+            var bb = Indicators.BollingerBands(Constant(10, 30), 20, 2);
+
+            bb.Middle.Data.Should().HaveCount(11);
+            bb.Band.Data.Should().HaveCount(11);
+            bb.Middle.Data.Should().OnlyContain(p => Math.Abs(p.Y - 10) < 1e-9);
+            bb.Band.Data.Should().OnlyContain(b => Math.Abs(b.YHigh - b.YLow) < 1e-9);
+        }
+
+        [Fact]
+        public void BollingerBands_VaryingInput_EnvelopeContainsMiddle()
+        {
+            var rng = new Random(42);
+            var source = Enumerable.Range(0, 100)
+                .Select(i => new PointD(i, 50 + rng.NextDouble() * 10)).ToList();
+
+            var bb = Indicators.BollingerBands(source, 20, 2);
+
+            for (var i = 0; i < bb.Middle.Data.Count; i++)
+            {
+                bb.Band.Data[i].YLow.Should().BeLessThan(bb.Middle.Data[i].Y);
+                bb.Band.Data[i].YHigh.Should().BeGreaterThan(bb.Middle.Data[i].Y);
+                bb.Band.Data[i].X.Should().Be(bb.Middle.Data[i].X);
+            }
+        }
+
+        [Fact]
+        public void Indicators_FromOhlcSeries_UseClosePrices()
+        {
+            var ohlc = new OhlcSeries(Enumerable.Range(0, 10)
+                .Select(i => new OhlcPoint(i, 1, 2, 0.5, 7.0)));
+
+            var sma = Indicators.Sma(ohlc, 5);
+
+            sma.Data.Should().OnlyContain(p => Math.Abs(p.Y - 7.0) < 1e-9);
+        }
+
+        [Fact]
+        public void Indicators_InvalidArguments_Throw()
+        {
+            FluentActions.Invoking(() => Indicators.Sma((IReadOnlyList<PointD>)null!, 3)).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => Indicators.Sma(Constant(1, 5), 0)).Should().Throw<ArgumentOutOfRangeException>();
+            FluentActions.Invoking(() => Indicators.Ema(Constant(1, 5), -1)).Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
+        public void Indicators_AreRenderableSeries()
+        {
+            var sma = Indicators.Sma(Constant(5, 20), 4);
+            var bb = Indicators.BollingerBands(Constant(5, 30), 10);
+
+            sma.Should().BeAssignableTo<SeriesBase>();
+            bb.Middle.Should().BeAssignableTo<SeriesBase>();
+            bb.Band.Should().BeAssignableTo<SeriesBase>();
+        }
+    }
+}

--- a/tests/FastCharts.Core.Tests/Interaction/ChartLinkGroupTests.cs
+++ b/tests/FastCharts.Core.Tests/Interaction/ChartLinkGroupTests.cs
@@ -1,0 +1,121 @@
+using FastCharts.Core;
+using FastCharts.Core.Interactivity;
+using FastCharts.Core.Primitives;
+using FluentAssertions;
+using Xunit;
+
+namespace FastCharts.Core.Tests.Interaction
+{
+    /// <summary>
+    /// Tests for cross-chart X axis linking (v1.3, P2-AX-LINK)
+    /// </summary>
+    public class ChartLinkGroupTests
+    {
+        [Fact]
+        public void LinkedCharts_ShareXRange_WhenOneZooms()
+        {
+            using var price = new ChartModel();
+            using var indicator = new ChartModel();
+            using var link = new ChartLinkGroup();
+            link.Add(price);
+            link.Add(indicator);
+
+            price.XAxis.VisibleRange = new FRange(10, 20);
+
+            indicator.XAxis.VisibleRange.Min.Should().Be(10);
+            indicator.XAxis.VisibleRange.Max.Should().Be(20);
+        }
+
+        [Fact]
+        public void LinkedCharts_SyncBothDirections()
+        {
+            using var a = new ChartModel();
+            using var b = new ChartModel();
+            using var link = new ChartLinkGroup();
+            link.Add(a);
+            link.Add(b);
+
+            b.XAxis.VisibleRange = new FRange(-5, 5);
+
+            a.XAxis.VisibleRange.Min.Should().Be(-5);
+            a.XAxis.VisibleRange.Max.Should().Be(5);
+        }
+
+        [Fact]
+        public void NewMember_AdoptsGroupRange()
+        {
+            using var a = new ChartModel();
+            using var b = new ChartModel();
+            using var link = new ChartLinkGroup();
+            link.Add(a);
+            a.XAxis.VisibleRange = new FRange(100, 200);
+
+            link.Add(b);
+
+            b.XAxis.VisibleRange.Min.Should().Be(100);
+            b.XAxis.VisibleRange.Max.Should().Be(200);
+        }
+
+        [Fact]
+        public void RemovedChart_StopsSyncing()
+        {
+            using var a = new ChartModel();
+            using var b = new ChartModel();
+            using var link = new ChartLinkGroup();
+            link.Add(a);
+            link.Add(b);
+
+            link.Remove(b).Should().BeTrue();
+            a.XAxis.VisibleRange = new FRange(1, 2);
+
+            b.XAxis.VisibleRange.Max.Should().NotBe(2);
+        }
+
+        [Fact]
+        public void PanOperation_PropagatesThroughLink()
+        {
+            using var a = new ChartModel();
+            using var b = new ChartModel();
+            using var link = new ChartLinkGroup();
+            link.Add(a);
+            link.Add(b);
+            a.XAxis.VisibleRange = new FRange(0, 10);
+
+            a.Pan(5, 0); // shift X by +5
+
+            b.XAxis.VisibleRange.Min.Should().Be(5);
+            b.XAxis.VisibleRange.Max.Should().Be(15);
+        }
+
+        [Fact]
+        public void LogAxisSwitch_KeepsLinkAlive()
+        {
+            using var a = new ChartModel();
+            using var b = new ChartModel();
+            using var link = new ChartLinkGroup();
+            link.Add(a);
+            link.Add(b);
+
+            a.XAxis.VisibleRange = new FRange(1, 100);
+            a.SetXAxisLogarithmic(); // replaces the X axis instance
+
+            a.XAxis.VisibleRange = new FRange(1, 50);
+            b.XAxis.VisibleRange.Max.Should().Be(50);
+        }
+
+        [Fact]
+        public void Dispose_UnlinksEverything()
+        {
+            using var a = new ChartModel();
+            using var b = new ChartModel();
+            var link = new ChartLinkGroup();
+            link.Add(a);
+            link.Add(b);
+
+            link.Dispose();
+            a.XAxis.VisibleRange = new FRange(7, 8);
+
+            b.XAxis.VisibleRange.Max.Should().NotBe(8);
+        }
+    }
+}

--- a/tests/FastCharts.Core.Tests/Series/OhlcCandlestickTests.cs
+++ b/tests/FastCharts.Core.Tests/Series/OhlcCandlestickTests.cs
@@ -1,0 +1,87 @@
+using System.Linq;
+using FastCharts.Core.Primitives;
+using FastCharts.Core.Series;
+using FluentAssertions;
+using Xunit;
+
+namespace FastCharts.Core.Tests.Series
+{
+    /// <summary>
+    /// Tests for enhanced candlestick features (v1.3): bull/bear colors, volume
+    /// </summary>
+    public class OhlcCandlestickTests
+    {
+        [Fact]
+        public void OhlcPoint_VolumeIsOptional()
+        {
+            var withoutVolume = new OhlcPoint(1, 10, 12, 9, 11);
+            var withVolume = new OhlcPoint(1, 10, 12, 9, 11, 5000);
+
+            withoutVolume.Volume.Should().BeNull();
+            withVolume.Volume.Should().Be(5000);
+        }
+
+        [Fact]
+        public void OhlcSeries_ColorAndVolumeDefaults()
+        {
+            var series = new OhlcSeries();
+
+            series.BullColor.Should().BeNull("null means theme-derived color");
+            series.BearColor.Should().BeNull();
+            series.ShowVolume.Should().BeFalse();
+            series.VolumePaneRatio.Should().Be(0.2);
+            series.VolumeOpacity.Should().Be(0.35);
+        }
+
+        [Fact]
+        public void OhlcSeries_CustomColors_AreStored()
+        {
+            var series = new OhlcSeries
+            {
+                BullColor = new ColorRgba(0, 200, 80),
+                BearColor = new ColorRgba(220, 40, 40)
+            };
+
+            series.BullColor!.Value.G.Should().Be(200);
+            series.BearColor!.Value.R.Should().Be(220);
+        }
+
+        [Fact]
+        public void OhlcSeries_WithVolume_RangesUnaffected()
+        {
+            // Volume renders in an overlay band; it must not distort the price Y range
+            var series = new OhlcSeries(new[]
+            {
+                new OhlcPoint(0, 10, 15, 8, 12, 1_000_000),
+                new OhlcPoint(1, 12, 18, 11, 17, 2_000_000)
+            });
+
+            var yRange = series.GetYRange();
+
+            yRange.Min.Should().Be(8);
+            yRange.Max.Should().Be(18);
+        }
+
+        [Fact]
+        public void OhlcSeries_RendersWithVolumeAndCustomColors()
+        {
+            using var model = new FastCharts.Core.ChartModel();
+            var series = new OhlcSeries(Enumerable.Range(0, 30).Select(i =>
+                new OhlcPoint(i, 100 + i, 105 + i, 95 + i, (i % 2 == 0) ? 103 + i : 97 + i, 1000 + (i * 10))))
+            {
+                ShowVolume = true,
+                BullColor = new ColorRgba(0, 200, 80),
+                BearColor = new ColorRgba(220, 40, 40)
+            };
+            model.AddSeries(series);
+
+            var renderer = new FastCharts.Rendering.Skia.SkiaChartRenderer();
+            using var stream = new System.IO.MemoryStream();
+
+            // Full render pipeline must succeed with volume band enabled
+            renderer.ExportPng(model, stream, 800, 600);
+
+            stream.Length.Should().BeGreaterThan(0);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Second step of the 1.2–1.5 plan: the finance feature set that premium WPF libraries (SciChart et al.) are known for, plus a release path that works entirely from the browser (no local git needed).

## Added

- **Enhanced candlesticks** (P2-SERIES-CANDLESTICK) — `OhlcSeries.BullColor` / `BearColor` (null = current theme-derived behavior), optional `OhlcPoint.Volume`, and `ShowVolume` drawing volume bars in a bottom band of the plot (`VolumePaneRatio`, `VolumeOpacity`), colored bull/bear — the classic trading layout.
- **Financial indicators** (P3-FIN-INDICATORS, first batch) — `Indicators.Sma` / `Ema` (SMA-seeded) / `BollingerBands` (middle `LineSeries` + ±kσ `BandSeries`). All return ready-to-add series; overloads accept `IReadOnlyList<PointD>` or an `OhlcSeries` (Close prices). O(n) sliding-window SMA/EMA. RSI/MACD deferred (need a secondary pane concept).
- **Linked charts** (P2-AX-LINK) — `ChartLinkGroup` keeps the visible X range of several `ChartModel`s in sync under zoom/pan (price + indicator pattern). Reentrancy-guarded, survives X-axis replacement (e.g. log switch), `Remove`/`Dispose` unlink cleanly. Built on a new `AxisBase.VisibleRangeChanged` event.
- **Release from the browser** — the *Publish NuGet Packages* workflow now supports `workflow_dispatch` with a `version` input: it creates the `vX.Y.Z` tag itself, then builds, tests, packs, pushes to NuGet and creates the GitHub release. Job granted `contents: write` for the tag push. (Motivation: tags can't be pushed from this environment, and the repo owner is currently phone-only.)

## Tests

- 530 tests pass locally (was 509): indicator math against hand-computed values, constant-input invariants, envelope containment, OHLC-close overloads, link-group bidirectional sync / late-join / removal / dispose / pan propagation / log-axis replacement, candlestick defaults & full render with volume band.
- `check_one_type_per_file.py` passes; versions bumped to 1.3.0.

## How to release (from any browser, once merged)

GitHub → **Actions** → *Publish NuGet Packages* → **Run workflow** → version `1.3.0` → Run. C'est tout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APwv9nzZjNwaf6r3rRumeE

---
_Generated by [Claude Code](https://claude.ai/code/session_01APwv9nzZjNwaf6r3rRumeE)_