### PR TITLE
feat(core): histogram with auto-binning (P2-HISTOGRAM) — first v1.5 brick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to FastCharts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### ✨ **Added — "Analytics" (v1.5, in progress)**
+
+- **Histogram with auto-binning** (P2-HISTOGRAM): `model.AddHistogram(values)` bins raw values into contiguous bars in one line. Bin count is chosen automatically (Sturges' rule) or can be fixed via `binCount`. NaN/infinities are ignored; all-identical values collapse to a single bar. The pure, unit-tested `HistogramBuilder.Build(values, binCount?)` returns a ready-to-add `BarSeries` (bars centered on each bin, width = bin width, Y = count).
+
 ## [1.4.0] - 2026-07-08
 
 ### ✨ **Added — "Large volumes & GPU"**

--- a/RoadMap.md
+++ b/RoadMap.md
@@ -194,9 +194,9 @@ Long-term target: feature parity with premium WPF charting (SciChart).
 - [x] Opt-in Skia GPU backend (T-PERF-GPU) — `FastChart.UseGpu` swaps SKElement→SKGLElement (default false, CPU path untouched); validated pixel-identical on net8 + net48 demos
 - [x] Geometry caching (T-PERF-CACHE) — per-series SKPath/pixel cache keyed on DataVersion + ranges + plot rect; dirty rectangles remain open
 
-### v1.5 — "Analytics"
+### v1.5 — "Analytics" (in progress)
 - Heatmap + color axis (P2-HEATMAP, P1-AX-COLOR)
-- Histogram with auto-binning (P2-HISTOGRAM): `model.AddHistogram(values)`
+- [x] Histogram with auto-binning (P2-HISTOGRAM): `model.AddHistogram(values)` — Sturges auto-bins, contiguous bars, `HistogramBuilder` unit-tested
 - Draggable text/shape annotations (P2-ANNOT-TEXT/SHAPE)
 
 ### Continuous (from 1.2)

--- a/demos/DemoApp.Net8/ViewModels/MainViewModel.cs
+++ b/demos/DemoApp.Net8/ViewModels/MainViewModel.cs
@@ -165,6 +165,7 @@ public sealed class MainViewModel : ReactiveObject, IDisposable
         Charts.Add(BuildRangeAnnotationDemo()); // 7
         Charts.Add(BuildLogarithmicAxisDemo()); // 8 - P1-AX-LOG
         Charts.Add(BuildLttbPerformanceDemo()); // 9 - P1-RESAMPLE-LTTB
+        Charts.Add(BuildHistogramDemo());       // 10 - P2-HISTOGRAM (v1.5)
     }
 
     private void ToggleTheme()
@@ -533,6 +534,32 @@ public sealed class MainViewModel : ReactiveObject, IDisposable
     /// <summary>
     /// P1-AX-LOG: Build a demo chart showcasing the LogarithmicAxis functionality
     /// </summary>
+    private static ChartModel BuildHistogramDemo()
+    {
+        var model = new ChartModel
+        {
+            Title = "Histogram (auto-binning) — model.AddHistogram(values)"
+        };
+
+        // Approximate a normal distribution (sum of uniforms → central limit theorem).
+        var random = new Random(42);
+        var samples = new List<double>();
+        for (var i = 0; i < 2000; i++)
+        {
+            var s = 0.0;
+            for (var j = 0; j < 6; j++)
+            {
+                s += random.NextDouble();
+            }
+
+            samples.Add(s - 3.0); // centered on 0
+        }
+
+        // One line: bins are chosen automatically (Sturges' rule).
+        model.AddHistogram(samples, title: "Distribution");
+        return model;
+    }
+
     private static ChartModel BuildLogarithmicAxisDemo()
     {
         var model = new ChartModel

--- a/src/FastCharts.Core/ChartModel.cs
+++ b/src/FastCharts.Core/ChartModel.cs
@@ -319,6 +319,23 @@ public sealed class ChartModel : ReactiveObject, IChartModel, IDisposable
         return series;
     }
 
+    /// <summary>
+    /// One-liner: bins raw values into a histogram and plots it as contiguous bars.
+    /// Bin count is chosen automatically (Sturges' rule) unless <paramref name="binCount"/>
+    /// is supplied. The view auto-fits the data.
+    /// </summary>
+    /// <param name="values">Raw sample values (NaN/infinities ignored)</param>
+    /// <param name="binCount">Optional fixed bin count; null = automatic</param>
+    /// <param name="title">Optional legend title</param>
+    /// <returns>The created bar series, for further customization</returns>
+    public BarSeries AddHistogram(IEnumerable<double> values, int? binCount = null, string? title = null)
+    {
+        var series = HistogramBuilder.Build(values, binCount);
+        series.Title = title;
+        AddSeries(series);
+        return series;
+    }
+
     private static List<BarPoint> ToBarPoints(IList<PointD> points)
     {
         var bars = new List<BarPoint>(points.Count);

--- a/src/FastCharts.Core/Series/HistogramBuilder.cs
+++ b/src/FastCharts.Core/Series/HistogramBuilder.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+
+namespace FastCharts.Core.Series;
+
+/// <summary>
+/// Builds a histogram <see cref="BarSeries"/> from raw values, with automatic bin
+/// sizing. Bins are contiguous (bar width = bin width) and each bar's Y is the count
+/// of values in that bin. Pure and side-effect free, so it is unit-testable on its own.
+/// </summary>
+public static class HistogramBuilder
+{
+    /// <summary>
+    /// Computes evenly spaced bins over the value range and returns a ready-to-add
+    /// <see cref="BarSeries"/> (bars centered on each bin, width = bin width, Y = count).
+    /// </summary>
+    /// <param name="values">Raw sample values. NaN and infinities are ignored.</param>
+    /// <param name="binCount">
+    /// Number of bins. When null or &lt;= 0, Sturges' rule picks a sensible count.
+    /// </param>
+    /// <returns>A bar series representing the histogram (empty if no finite values).</returns>
+    public static BarSeries Build(IEnumerable<double> values, int? binCount = null)
+    {
+        if (values == null)
+        {
+            throw new ArgumentNullException(nameof(values));
+        }
+
+        var samples = new List<double>();
+        foreach (var v in values)
+        {
+            if (!double.IsNaN(v) && !double.IsInfinity(v))
+            {
+                samples.Add(v);
+            }
+        }
+
+        var series = new BarSeries { Baseline = 0.0 };
+        if (samples.Count == 0)
+        {
+            return series;
+        }
+
+        var min = samples[0];
+        var max = samples[0];
+        for (var i = 1; i < samples.Count; i++)
+        {
+            if (samples[i] < min)
+            {
+                min = samples[i];
+            }
+
+            if (samples[i] > max)
+            {
+                max = samples[i];
+            }
+        }
+
+        var range = max - min;
+        if (range <= 0)
+        {
+            // All values identical: a single unit-wide bar holding every sample.
+            series.Width = 1.0;
+            series.Data.Add(new BarPoint(min, samples.Count));
+            return series;
+        }
+
+        var bins = (binCount.HasValue && binCount.Value > 0) ? binCount.Value : SturgesBinCount(samples.Count);
+        var binWidth = range / bins;
+        var counts = new int[bins];
+        for (var i = 0; i < samples.Count; i++)
+        {
+            var idx = (int)((samples[i] - min) / binWidth);
+            if (idx < 0)
+            {
+                idx = 0;
+            }
+            else if (idx >= bins)
+            {
+                idx = bins - 1; // the maximum value falls into the last bin
+            }
+
+            counts[idx]++;
+        }
+
+        series.Width = binWidth;
+        for (var b = 0; b < bins; b++)
+        {
+            var center = min + ((b + 0.5) * binWidth);
+            series.Data.Add(new BarPoint(center, counts[b]));
+        }
+
+        return series;
+    }
+
+    /// <summary>
+    /// Sturges' rule: <c>ceil(log2(n) + 1)</c>, clamped to at least one bin.
+    /// </summary>
+    private static int SturgesBinCount(int n)
+    {
+        if (n <= 1)
+        {
+            return 1;
+        }
+
+        var k = (int)Math.Ceiling(Math.Log(n, 2) + 1);
+        return k < 1 ? 1 : k;
+    }
+}

--- a/tests/FastCharts.Core.Tests/HistogramBuilderTests.cs
+++ b/tests/FastCharts.Core.Tests/HistogramBuilderTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Linq;
+
+using FastCharts.Core;
+using FastCharts.Core.Series;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace FastCharts.Core.Tests;
+
+public class HistogramBuilderTests
+{
+    [Fact]
+    public void BuildBinsValuesIntoRequestedBinCount()
+    {
+        // 0..9 (10 values) into 5 bins: every value is counted, exactly 5 bars produced.
+        var values = Enumerable.Range(0, 10).Select(i => (double)i);
+
+        var series = HistogramBuilder.Build(values, binCount: 5);
+
+        series.Data.Should().HaveCount(5);
+        series.Data.Sum(b => b.Y).Should().Be(10);
+        series.Width.Should().BeApproximately(9.0 / 5.0, 1e-12); // range/bins
+    }
+
+    [Fact]
+    public void BuildBarWidthEqualsBinWidthAndCountsAreExact()
+    {
+        var values = new double[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+
+        var series = HistogramBuilder.Build(values, binCount: 5);
+
+        var binWidth = (10.0 - 0.0) / 5.0; // 2.0
+        series.Width.Should().Be(binWidth);
+        series.Data.Sum(b => b.Y).Should().Be(values.Length); // every sample counted once
+        // First bar centered on first bin.
+        series.Data[0].X.Should().Be(0 + (0.5 * binWidth));
+    }
+
+    [Fact]
+    public void BuildMaxValueLandsInLastBin()
+    {
+        var values = new double[] { 0, 10 };
+
+        var series = HistogramBuilder.Build(values, binCount: 2);
+
+        series.Data.Should().HaveCount(2);
+        series.Data[0].Y.Should().Be(1); // the 0
+        series.Data[1].Y.Should().Be(1); // the 10 clamps into last bin, not a 3rd bin
+    }
+
+    [Fact]
+    public void BuildAllIdenticalValuesProducesSingleBar()
+    {
+        var values = Enumerable.Repeat(7.0, 25);
+
+        var series = HistogramBuilder.Build(values);
+
+        series.Data.Should().HaveCount(1);
+        series.Data[0].X.Should().Be(7.0);
+        series.Data[0].Y.Should().Be(25);
+        series.Width.Should().Be(1.0);
+    }
+
+    [Fact]
+    public void BuildEmptyInputProducesEmptySeries()
+    {
+        var series = HistogramBuilder.Build(Array.Empty<double>());
+
+        series.IsEmpty.Should().BeTrue();
+        series.Data.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildIgnoresNaNAndInfinity()
+    {
+        var values = new double[] { 1, 2, double.NaN, 3, double.PositiveInfinity, 4, double.NegativeInfinity };
+
+        var series = HistogramBuilder.Build(values, binCount: 3);
+
+        // Only 1,2,3,4 are finite => 4 samples counted.
+        series.Data.Sum(b => b.Y).Should().Be(4);
+    }
+
+    [Fact]
+    public void BuildAutoBinCountFollowsSturgesRule()
+    {
+        // Sturges: ceil(log2(n) + 1). n=100 => ceil(6.64+1)=8.
+        var values = Enumerable.Range(0, 100).Select(i => (double)i);
+
+        var series = HistogramBuilder.Build(values);
+
+        series.Data.Should().HaveCount(8);
+    }
+
+    [Fact]
+    public void BuildNullThrows()
+    {
+        Action act = () => HistogramBuilder.Build(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void AddHistogramAddsSeriesAndReturnsIt()
+    {
+        var model = new ChartModel();
+        var values = Enumerable.Range(0, 50).Select(i => (double)i);
+
+        var series = model.AddHistogram(values, binCount: 10, title: "Dist");
+
+        series.Should().NotBeNull();
+        series.Title.Should().Be("Dist");
+        model.Series.Should().Contain(series);
+        series.Data.Should().HaveCount(10);
+    }
+}


### PR DESCRIPTION
First brick of **v1.5 "Analytics"**.

### `model.AddHistogram(values)`
Bins raw values into contiguous bars in one line. Bin count is auto-selected (Sturges' rule) or fixed via `binCount`.

- Pure, side-effect-free `HistogramBuilder.Build(values, binCount?)` returns a ready-to-add `BarSeries` (bars centered on each bin, `Width` = bin width so bars touch, `Y` = count). The binning math is unit-tested on its own — **9 tests** covering: fixed bin count, exact counts/width, max-value-in-last-bin, all-identical→single bar, empty input, NaN/∞ filtering, Sturges auto-count, null guard, and the `ChartModel.AddHistogram` wiring.
- KISS: mirrors the existing `AddSeries` one-liners; reuses `BarSeries` rendering (no new renderer).

**Validation:** new "Distribution" demo chart (index 10) renders a ~Gaussian sample via the one-liner — verified visually (clean bell-shaped, contiguous bars). 546 Core tests green.

CHANGELOG `Unreleased` section + RoadMap v1.5 histogram checked. No version bump (v1.5 not released).

🤖 Generated with [Claude Code](https://claude.com/claude-code)